### PR TITLE
Introduce dedicated Task page and MiniTaskMatrix; refactor Life/Social maps, UI copy, and xyflow visuals

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,17 +1,14 @@
 import { type ReactElement, useEffect, useMemo, useState } from 'react';
 import { AchievementToast } from './components/AchievementToast';
-import { AchievementsPanel } from './components/AchievementsPanel';
-import { ActivityLog } from './components/ActivityLog';
 import { HomePage } from './components/HomePage';
 import { LifeMapPage } from './components/LifeMapPage';
 import { LifeOSNav } from './components/LifeOSNav';
 import { LogPage } from './components/LogPage';
 import { OnboardingFlow } from './components/OnboardingFlow';
 import { ProfilePage } from './components/ProfilePage';
-import { PriorityMap } from './components/PriorityMap';
 import { TaskForm } from './components/TaskForm';
 import { SocialPage } from './components/SocialPage';
-import { TaskList } from './components/TaskList';
+import { TaskPage } from './components/TaskPage';
 import { useLocalStorage } from './hooks/useLocalStorage';
 import type { Achievement, ActivityType, LifecycleStatus, LifeOSModule, PressureBreakdown, PressureCalibrationSnapshot, PressureHistoryEventType, PressureHistoryRecord, Task, TaskInput, UserProfile } from './types/task';
 import {
@@ -336,6 +333,8 @@ function App() {
     closeForm();
   }
 
+
+
   function archiveTask(task: Task, lifecycleStatus: Exclude<LifecycleStatus, 'active'>) {
     const now = new Date().toISOString();
     const nextTasks = normalizedTasks.map((item) =>
@@ -377,18 +376,19 @@ function App() {
     );
   }
 
+
+
   function startEditing(task: Task) {
     setEditingTask(task);
     setIsFormOpen(true);
   }
-
 
   const taskFormOverlay = isFormOpen ? (
     <div className="fixed inset-0 z-40 flex items-center justify-center bg-slate-950/15 px-4 py-6 backdrop-blur-sm">
       <section className="max-h-[calc(100vh-3rem)] w-full max-w-5xl overflow-y-auto rounded-[2rem] border border-white/80 bg-white/90 p-5 shadow-2xl shadow-slate-300/60">
         <div className="mb-4 flex items-center justify-between gap-4">
           <div>
-            <p className="text-sm font-semibold uppercase tracking-[0.22em] text-slate-400">项目表单</p>
+            <p className="text-sm font-semibold tracking-[0.22em] text-slate-400">项目表单</p>
             <h2 className="mt-1 text-3xl font-semibold tracking-tight text-slate-950">{editingTask ? '编辑项目' : '新建项目'}</h2>
           </div>
           <button type="button" onClick={closeForm} className="rounded-full bg-slate-100 px-4 py-2 text-sm font-semibold text-slate-600 hover:bg-slate-200">
@@ -400,34 +400,21 @@ function App() {
     </div>
   ) : null;
 
-  const taskManagerModule = (
-    <>
-      <header className="flex flex-wrap items-center justify-between gap-4 rounded-[2rem] border border-white/70 bg-white/75 p-6 shadow-xl shadow-slate-200/60 backdrop-blur">
-        <div>
-          <p className="text-sm font-semibold uppercase tracking-[0.24em] text-slate-500">Task Manager · v0.9 foundation</p>
-          <h1 className="mt-2 text-4xl font-semibold tracking-tight text-slate-950 md:text-5xl">任务系统</h1>
-          <p className="mt-3 max-w-2xl text-slate-600">完整任务地图、活动列表与长期归档。首页只保留日常控制台。</p>
-        </div>
-        <button onClick={() => setIsFormOpen(true)} className="rounded-full bg-slate-950 px-6 py-3 text-sm font-semibold text-white shadow-lg shadow-slate-900/10 hover:bg-slate-700">
-          添加项目
-        </button>
-      </header>
 
-
-      <div className="grid gap-6 xl:grid-cols-[1.2fr_0.8fr]">
-        <PriorityMap tasks={activeTasks} />
-        <div className="space-y-6">
-          <TaskList tasks={activeTasks} onArchive={archiveTask} onDelete={deleteTask} onEdit={startEditing} />
-          <ActivityLog tasks={normalizedTasks} onDelete={deleteTask} onReviewNoteChange={updateReviewNote} />
-        </div>
-      </div>
-
-      <AchievementsPanel achievements={normalizedAchievements} />
-    </>
+  const taskModule = (
+    <TaskPage
+      activeTasks={activeTasks}
+      achievements={normalizedAchievements}
+      onAddTask={() => setIsFormOpen(true)}
+      onArchiveTask={archiveTask}
+      onDeleteTask={deleteTask}
+      onEditTask={startEditing}
+    />
   );
 
   const moduleContent: Record<LifeOSModule, ReactElement> = {
-    home: <><HomePage pressure={pressure} pressureHistory={normalizedPressureHistory} recommendedTasks={recommendedTasks} activeTasks={activeTasks} tasks={normalizedTasks} onAddTask={() => setIsFormOpen(true)} onRecalibrate={openRecalibration} onDeleteTask={deleteTask} onReviewNoteChange={updateReviewNote} />{taskManagerModule}</>,
+    home: <HomePage pressure={pressure} pressureHistory={normalizedPressureHistory} recommendedTasks={recommendedTasks} activeTasks={activeTasks} tasks={normalizedTasks} onAddTask={() => setIsFormOpen(true)} onRecalibrate={openRecalibration} onOpenTasks={() => setActiveModule('task')} />,
+    task: taskModule,
     map: <LifeMapPage />,
     social: <SocialPage />,
     log: <LogPage tasks={normalizedTasks} onDelete={deleteTask} onReviewNoteChange={updateReviewNote} />,
@@ -441,7 +428,7 @@ function App() {
       {isRecalibrationOpen ? (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/15 px-4 backdrop-blur-sm">
           <section className="w-full max-w-lg rounded-[2rem] border border-white/80 bg-white/95 p-6 shadow-2xl shadow-slate-300/60">
-            <p className="text-sm font-semibold uppercase tracking-[0.22em] text-slate-400">Pressure Recalibration</p>
+            <p className="text-sm font-semibold tracking-[0.22em] text-slate-400">压力校准</p>
             <h2 className="mt-3 text-3xl font-semibold tracking-tight text-slate-950">此刻这组任务让你感觉有多大压力？</h2>
             <p className="mt-3 text-sm leading-6 text-slate-500">系统会读取当前进行中任务负载，并用你的主观感受重新计算个体压力映射系数。</p>
             <div className="mt-6 rounded-3xl bg-slate-50/90 p-5 ring-1 ring-white/80">

--- a/src/components/AchievementsPanel.tsx
+++ b/src/components/AchievementsPanel.tsx
@@ -21,7 +21,7 @@ export function AchievementsPanel({ achievements }: AchievementsPanelProps) {
     <section className="rounded-[2rem] border border-white/70 bg-white/75 p-5 shadow-xl shadow-slate-200/60 backdrop-blur">
       <div className="flex items-center justify-between gap-4">
         <div>
-          <p className="text-sm font-semibold text-slate-500">轻成就</p>
+          <p className="text-sm font-semibold text-slate-500">成就系统</p>
           <h2 className="text-2xl font-semibold text-slate-950">最近与下一步</h2>
           <p className="mt-1 text-sm text-slate-500">只显示最接近的 4 个目标，保留一点正反馈。</p>
         </div>

--- a/src/components/DataSafetyPanel.tsx
+++ b/src/components/DataSafetyPanel.tsx
@@ -73,13 +73,13 @@ export function DataSafetyPanel() {
     <section className="rounded-[2rem] border border-white/70 bg-white/75 p-5 shadow-xl shadow-slate-200/60 backdrop-blur">
       <div className="flex flex-wrap items-center justify-between gap-4">
         <div>
-          <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-400">Data Safety · v0.7</p>
+          <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-400">数据安全 · v0.7</p>
           <h2 className="mt-1 text-2xl font-semibold tracking-tight text-slate-950">备份与恢复中心</h2>
           <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-500">统一导出任务、压力、人生地图、社交图谱、日志与设置；本地会自动保留滚动安全快照。</p>
         </div>
         <div className="flex flex-wrap gap-2">
-          <button type="button" onClick={handleExport} className="rounded-full bg-slate-950 px-5 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-slate-700">Export Data</button>
-          <button type="button" onClick={handleImportClick} className="rounded-full bg-white/85 px-5 py-2.5 text-sm font-semibold text-slate-700 shadow-sm ring-1 ring-slate-200 hover:bg-slate-50">Import Data</button>
+          <button type="button" onClick={handleExport} className="rounded-full bg-slate-950 px-5 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-slate-700">导出数据</button>
+          <button type="button" onClick={handleImportClick} className="rounded-full bg-white/85 px-5 py-2.5 text-sm font-semibold text-slate-700 shadow-sm ring-1 ring-slate-200 hover:bg-slate-50">导入数据</button>
           <input ref={fileInputRef} type="file" accept="application/json,.json" onChange={handleImport} className="sr-only" />
         </div>
       </div>

--- a/src/components/HomePage.tsx
+++ b/src/components/HomePage.tsx
@@ -1,5 +1,5 @@
 import type { PressureBreakdown, PressureHistoryRecord, Task } from '../types/task';
-import { ActivityLog } from './ActivityLog';
+import { MiniTaskMatrix } from './MiniTaskMatrix';
 import { PressureCard } from './PressureCard';
 import { RecommendationCard } from './RecommendationCard';
 
@@ -11,70 +11,45 @@ interface HomePageProps {
   tasks: Task[];
   onAddTask: () => void;
   onRecalibrate: () => void;
-  onDeleteTask: (taskId: string) => void;
-  onReviewNoteChange: (taskId: string, reviewNote: string) => void;
+  onOpenTasks: () => void;
 }
 
-function pressureTone(state: PressureBreakdown['state']): string {
-  if (state === 'burnout') return 'text-rose-600 bg-rose-50 ring-rose-100';
-  if (state === 'overload') return 'text-orange-600 bg-orange-50 ring-orange-100';
-  if (state === 'high') return 'text-amber-600 bg-amber-50 ring-amber-100';
-  if (state === 'manageable') return 'text-sky-600 bg-sky-50 ring-sky-100';
-  return 'text-emerald-600 bg-emerald-50 ring-emerald-100';
-}
-
-export function HomePage({ pressure, pressureHistory, recommendedTasks, activeTasks, tasks, onAddTask, onRecalibrate, onDeleteTask, onReviewNoteChange }: HomePageProps) {
+export function HomePage({ pressure, pressureHistory, recommendedTasks, activeTasks, tasks, onAddTask, onRecalibrate, onOpenTasks }: HomePageProps) {
   const completedCount = tasks.filter((task) => task.lifecycleStatus === 'completed').length;
-  const archivedCount = tasks.filter((task) => task.lifecycleStatus !== 'active').length;
-  const nextTask = recommendedTasks[0];
 
   return (
     <section className="space-y-5 md:space-y-6">
-      <header className="overflow-hidden rounded-[2rem] border border-white/70 bg-white/75 p-5 shadow-xl shadow-slate-200/60 backdrop-blur md:p-6">
-        <div className="grid gap-5 lg:grid-cols-[1fr_auto] lg:items-end">
-          <div>
-            <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-400">VD Home · Daily Control Center</p>
-            <h1 className="mt-2 text-3xl font-semibold tracking-tight text-slate-950 md:text-5xl">首页</h1>
-            <p className="mt-3 max-w-2xl text-sm leading-6 text-slate-500">先看压力，再选下一步。VD 会把任务、节奏和日志收束成每天的控制台。</p>
-          </div>
-          <div className="grid grid-cols-3 gap-2 rounded-3xl bg-slate-50/80 p-2 ring-1 ring-white/80 sm:min-w-[22rem]">
-            <div className="rounded-2xl bg-white/85 px-3 py-3 text-center"><p className="text-2xl font-semibold text-slate-950">{activeTasks.length}</p><p className="text-xs text-slate-400">进行中</p></div>
-            <div className="rounded-2xl bg-white/85 px-3 py-3 text-center"><p className="text-2xl font-semibold text-slate-950">{completedCount}</p><p className="text-xs text-slate-400">已完成</p></div>
-            <div className="rounded-2xl bg-white/85 px-3 py-3 text-center"><p className="text-2xl font-semibold text-slate-950">{archivedCount}</p><p className="text-xs text-slate-400">日志</p></div>
-          </div>
-        </div>
-      </header>
-
       <PressureCard pressure={pressure} history={pressureHistory} onRecalibrate={onRecalibrate} />
       <RecommendationCard tasks={recommendedTasks} />
+      <MiniTaskMatrix tasks={activeTasks} onOpenTasks={onOpenTasks} />
 
-      <div className="grid gap-5 xl:grid-cols-[0.95fr_1.05fr]">
-        <section className="rounded-[2rem] border border-white/70 bg-white/75 p-5 shadow-xl shadow-slate-200/60 backdrop-blur">
-          <div className="flex flex-wrap items-start justify-between gap-4">
-            <div>
-              <p className="text-sm font-semibold text-slate-500">当前状态</p>
-              <h2 className="mt-1 text-2xl font-semibold text-slate-950">{nextTask ? `下一步：${nextTask.title}` : '今天没有强制推进项'}</h2>
-            </div>
-            <span className={`rounded-full px-3 py-1 text-sm font-semibold ring-1 ${pressureTone(pressure.state)}`}>{pressure.label}</span>
+      <section className="rounded-[2rem] border border-white/70 bg-white/75 p-4 shadow-xl shadow-slate-200/60 backdrop-blur md:p-5">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <p className="text-sm font-semibold text-slate-500">快速操作</p>
+            <p className="mt-1 text-xs leading-5 text-slate-400">首页只保留今天需要立刻判断的入口。</p>
           </div>
-          <p className="mt-4 text-sm leading-6 text-slate-500">{pressure.recommendation}</p>
-          <div className="mt-5 grid gap-3 sm:grid-cols-2">
-            <button type="button" onClick={onAddTask} className="rounded-3xl bg-slate-950 px-4 py-4 text-left text-sm font-semibold text-white shadow-sm hover:bg-slate-700">添加项目<span className="mt-1 block text-xs font-medium text-slate-300">把脑内占用移到系统里</span></button>
-            <button type="button" onClick={onRecalibrate} className="rounded-3xl bg-white/85 px-4 py-4 text-left text-sm font-semibold text-slate-700 shadow-sm ring-1 ring-slate-200 hover:bg-slate-50">重新校准压力<span className="mt-1 block text-xs font-medium text-slate-400">让模型贴近此刻体感</span></button>
+          <div className="flex flex-wrap gap-2">
+            <span className="rounded-full bg-slate-50 px-3 py-1.5 text-xs font-semibold text-slate-500 ring-1 ring-white/80">进行中 {activeTasks.length}</span>
+            <span className="rounded-full bg-slate-50 px-3 py-1.5 text-xs font-semibold text-slate-500 ring-1 ring-white/80">已完成 {completedCount}</span>
           </div>
-        </section>
+        </div>
+        <div className="mt-4 grid gap-3 sm:grid-cols-2">
+          <button type="button" onClick={onAddTask} className="rounded-3xl bg-slate-950 px-4 py-3 text-left text-sm font-semibold text-white shadow-sm hover:bg-slate-700">
+            添加项目
+            <span className="mt-1 block text-xs font-medium text-slate-300">把脑内占用移到系统里</span>
+          </button>
+          <button type="button" onClick={onRecalibrate} className="rounded-3xl bg-white/85 px-4 py-3 text-left text-sm font-semibold text-slate-700 shadow-sm ring-1 ring-slate-200 hover:bg-slate-50">
+            重新校准压力
+            <span className="mt-1 block text-xs font-medium text-slate-400">让模型贴近此刻体感</span>
+          </button>
+        </div>
+      </section>
 
-        <section className="rounded-[2rem] border border-white/70 bg-white/75 p-5 shadow-xl shadow-slate-200/60 backdrop-blur">
-          <p className="text-sm font-semibold text-slate-500">未来智能区</p>
-          <h2 className="mt-1 text-2xl font-semibold text-slate-950">AI 协同占位</h2>
-          <p className="mt-3 text-sm leading-6 text-slate-500">这里预留给未来的本地上下文总结、节奏建议和行动复盘。当前版本保持本地优先，不调用任何 AI 或云端服务。</p>
-          <div className="mt-5 grid gap-3 sm:grid-cols-3">
-            {['本地上下文', '节奏洞察', '行动建议'].map((item) => <div key={item} className="rounded-2xl bg-slate-50/80 px-3 py-3 text-center text-xs font-semibold text-slate-500 ring-1 ring-white/80">{item}</div>)}
-          </div>
-        </section>
-      </div>
-
-      <ActivityLog tasks={tasks} limit={4} title="最近日志" onDelete={onDeleteTask} onReviewNoteChange={onReviewNoteChange} />
+      <section className="rounded-[1.5rem] border border-white/70 bg-white/55 px-4 py-3 text-xs text-slate-400 shadow-sm shadow-slate-200/50 backdrop-blur">
+        <span className="font-semibold text-slate-500">未来智能区：</span>
+        本地总结、节奏洞察与行动建议暂不启用；当前版本不调用 AI 或云端服务。
+      </section>
     </section>
   );
 }

--- a/src/components/LifeMapPage.tsx
+++ b/src/components/LifeMapPage.tsx
@@ -4,22 +4,24 @@ import { useLocalStorage } from '../hooks/useLocalStorage';
 import { storageKeys } from '../storage';
 import type { LifeMapNodeData } from '../types/task';
 
-const CURRENT_LIFE_MAP_LAYOUT_VERSION = 3;
-const LIFE_CENTER = { x: 620, y: 430 };
-const ORBIT_STEP = 120;
-const NODE_GAP = 170;
-const MAX_LIFE_DISTANCE = 900;
+const CURRENT_LIFE_MAP_LAYOUT_VERSION = 4;
+const LIFE_CENTER = { x: 600, y: 560 };
+const NODE_GAP = 150;
+const TREE_COLUMNS = [120, 360, 600, 840];
+const TREE_ROWS = [150, 330];
 
 type LifeNode = Node<LifeMapNodeData>;
+type LifeEdgeData = { route: 'orthogonal'; label?: string };
 
 const domainSeeds: LifeMapNodeData[] = [
-  { title: '学习', description: '课程、技能与日常学习节奏。', color: '#bfdbfe' },
-  { title: '研究', description: '长期问题、论文与实验推进。', color: '#ddd6fe' },
-  { title: '健身', description: '训练、力量与身体状态。', color: '#bbf7d0' },
-  { title: '资产管理', description: '收入、支出、储蓄与风险边界。', color: '#fde68a' },
-  { title: '社交', description: '关系维护与社交能量。', color: '#fecdd3' },
-  { title: '内容', description: '表达、作品与内容资产。', color: '#bae6fd' },
-  { title: '健康', description: '睡眠、饮食与基础健康信号。', color: '#d9f99d' },
+  { title: '学习', description: '课程、技能与日常学习节奏。', color: '#dbeafe' },
+  { title: '研究', description: '长期问题、论文与实验推进。', color: '#ede9fe' },
+  { title: '健身', description: '训练、力量与身体状态。', color: '#dcfce7' },
+  { title: '健康', description: '睡眠、饮食与基础健康信号。', color: '#ecfccb' },
+  { title: '社交', description: '关系维护与社交能量。', color: '#ffe4e6' },
+  { title: '资产管理', description: '收入、支出、储蓄与风险边界。', color: '#fef3c7' },
+  { title: '内容', description: '表达、作品与内容资产。', color: '#cffafe' },
+  { title: '个人思考', description: '复盘、价值观与长期判断。', color: '#e2e8f0' },
 ];
 
 const legacyDomainTitleMap: Record<string, string> = {
@@ -47,49 +49,36 @@ function normalizeLifeTitle(title: string, nodeId?: string): string {
   return title || '未命名节点';
 }
 
-function orbitPoint(index: number, radius = 300): LifeNode['position'] {
-  const angle = (Math.PI * 2 * index) / Math.max(domainSeeds.length, 8) - Math.PI / 2;
-  return { x: Math.round(LIFE_CENTER.x + Math.cos(angle) * radius), y: Math.round(LIFE_CENTER.y + Math.sin(angle) * radius) };
-}
-
-function distanceFromCenter(position: LifeNode['position']): number {
-  return Math.hypot(position.x - LIFE_CENTER.x, position.y - LIFE_CENTER.y);
-}
-
-function isValidLifePosition(position: unknown): position is LifeNode['position'] {
-  if (!position || typeof position !== 'object') return false;
-  const candidate = position as LifeNode['position'];
-  return Number.isFinite(candidate.x) && Number.isFinite(candidate.y) && distanceFromCenter(candidate) <= MAX_LIFE_DISTANCE;
+function treePosition(index: number): LifeNode['position'] {
+  if (index < 4) return { x: TREE_COLUMNS[index], y: TREE_ROWS[1] };
+  if (index < 8) return { x: TREE_COLUMNS[index - 4], y: TREE_ROWS[0] };
+  const extraIndex = index - 8;
+  const row = Math.floor(extraIndex / 4);
+  const column = extraIndex % 4;
+  return { x: TREE_COLUMNS[column], y: Math.max(40, TREE_ROWS[0] - (row + 1) * 135) };
 }
 
 function hasCollision(position: LifeNode['position'], nodes: LifeNode[]): boolean {
   return nodes.some((node) => Math.hypot(node.position.x - position.x, node.position.y - position.y) < NODE_GAP);
 }
 
-function findAvailablePosition(nodes: LifeNode[], preferredIndex = nodes.length): LifeNode['position'] {
-  const preferred = orbitPoint(preferredIndex);
-  if (!hasCollision(preferred, nodes) && distanceFromCenter(preferred) <= MAX_LIFE_DISTANCE) return preferred;
-  for (let ring = 0; ring < 5; ring += 1) {
-    const radius = 240 + ring * ORBIT_STEP;
-    const slots = 8 + ring * 6;
-    for (let slot = 0; slot < slots; slot += 1) {
-      const angle = (Math.PI * 2 * slot) / slots - Math.PI / 2;
-      const position = { x: Math.round(LIFE_CENTER.x + Math.cos(angle) * radius), y: Math.round(LIFE_CENTER.y + Math.sin(angle) * radius) };
-      if (!hasCollision(position, nodes) && distanceFromCenter(position) <= MAX_LIFE_DISTANCE) return position;
-    }
+function findAvailablePosition(nodes: LifeNode[]): LifeNode['position'] {
+  for (let index = 0; index < 40; index += 1) {
+    const position = treePosition(index);
+    if (!hasCollision(position, nodes)) return position;
   }
-  return { x: LIFE_CENTER.x + 420, y: LIFE_CENTER.y + 220 };
+  return { x: LIFE_CENTER.x + 360, y: LIFE_CENTER.y - 520 };
 }
 
 function createSeedNodes(): LifeNode[] {
   return [
-    { id: 'me', position: LIFE_CENTER, data: { title: '我', description: 'LifeOS 的中心节点', currentStage: '', notes: '', color: '#cbd5e1' } },
-    ...domainSeeds.map((domain, index) => ({ id: `life-${index}`, position: orbitPoint(index), data: domain })),
+    { id: 'me', type: 'life', position: LIFE_CENTER, data: { title: '我', description: 'LifeOS 的中心节点', currentStage: '', notes: '', color: '#cbd5e1' } },
+    ...domainSeeds.map((domain, index) => ({ id: `life-${index}`, type: 'life', position: treePosition(index), data: domain })),
   ];
 }
 
-function createEdges(nodes: LifeNode[]): Edge[] {
-  return nodes.filter((node) => node.id !== 'me').map((node) => ({ id: `me-${node.id}`, source: 'me', target: node.id }));
+function createEdges(nodes: LifeNode[]): Edge<LifeEdgeData>[] {
+  return nodes.filter((node) => node.id !== 'me').map((node) => ({ id: `me-${node.id}`, source: 'me', target: node.id, data: { route: 'orthogonal' } }));
 }
 
 function normalizeNodes(nodes: unknown, forceRelayout = false): LifeNode[] {
@@ -98,6 +87,7 @@ function normalizeNodes(nodes: unknown, forceRelayout = false): LifeNode[] {
   const storedCenter = rawNodes.find((node) => node.id === 'me');
   const centerNode: LifeNode = {
     id: 'me',
+    type: 'life',
     position: LIFE_CENTER,
     data: {
       title: storedCenter?.data?.title || '我',
@@ -108,25 +98,26 @@ function normalizeNodes(nodes: unknown, forceRelayout = false): LifeNode[] {
     },
   };
   const existing: LifeNode[] = [centerNode];
-  const people = rawNodes
+  const lifeNodes = rawNodes
     .filter((node) => node.id !== 'me')
-    .map((node) => {
-      const position = !forceRelayout && isValidLifePosition(node.position) && !hasCollision(node.position, existing) ? node.position : findAvailablePosition(existing);
+    .map((node, index) => {
+      const position = forceRelayout ? treePosition(index) : node.position && Number.isFinite(node.position.x) && Number.isFinite(node.position.y) && !hasCollision(node.position, existing) ? node.position : findAvailablePosition(existing);
       const nextNode: LifeNode = {
         id: node.id || crypto.randomUUID(),
+        type: 'life',
         position,
         data: {
           title: normalizeLifeTitle(node.data?.title || '', node.id),
           description: node.data?.description || '',
           currentStage: node.data?.currentStage || '',
           notes: node.data?.notes || '',
-          color: node.data?.color || '#e2e8f0',
+          color: node.data?.color || domainSeeds[index]?.color || '#e2e8f0',
         },
       };
       existing.push(nextNode);
       return nextNode;
     });
-  return [centerNode, ...people];
+  return [centerNode, ...lifeNodes];
 }
 
 function getLifeMapData(node: LifeNode): LifeMapNodeData {
@@ -153,7 +144,7 @@ export function LifeMapPage() {
 
   function addNode() {
     const baseNodes = normalizeNodes(storedNodes);
-    const newNode: LifeNode = { id: crypto.randomUUID(), position: findAvailablePosition(baseNodes), data: { title: '新的生活节点', description: '', currentStage: '', notes: '', color: '#e0f2fe' } };
+    const newNode: LifeNode = { id: crypto.randomUUID(), type: 'life', position: findAvailablePosition(baseNodes), data: { title: '新的生活节点', description: '', currentStage: '', notes: '', color: '#e0f2fe' } };
     setStoredNodes([...baseNodes, newNode]);
     setEditingNode(newNode);
   }
@@ -173,7 +164,11 @@ export function LifeMapPage() {
   return (
     <section className="space-y-6">
       <div className="flex flex-wrap items-end justify-between gap-4 rounded-[2rem] border border-white/70 bg-white/75 p-6 shadow-xl shadow-slate-200/60 backdrop-blur">
-        <div><p className="text-sm font-semibold uppercase tracking-[0.24em] text-slate-400">人生地图</p><h1 className="mt-2 text-4xl font-semibold tracking-tight text-slate-950">人生地图</h1><p className="mt-3 max-w-2xl text-sm leading-6 text-slate-500">把生活领域摊开成一张可拖动的地图。点击节点编辑，拖动时不会误开弹窗。</p></div>
+        <div>
+          <p className="text-sm font-semibold tracking-[0.24em] text-slate-400">人生结构树</p>
+          <h1 className="mt-2 text-4xl font-semibold tracking-tight text-slate-950">人生地图</h1>
+          <p className="mt-3 max-w-2xl text-sm leading-6 text-slate-500">用路线图 / 技能树方式整理生活领域：底部是“我”，分支向上展开。点击节点编辑，拖动时不会误开弹窗。</p>
+        </div>
         <button type="button" onClick={addNode} className="rounded-full bg-slate-950 px-5 py-3 text-sm font-semibold text-white shadow-sm hover:bg-slate-700">添加节点</button>
       </div>
 
@@ -182,7 +177,7 @@ export function LifeMapPage() {
       </div>
 
       {editingNode ? (
-        <div className="fixed inset-0 z-40 flex items-center justify-center bg-slate-950/15 px-4 backdrop-blur-sm"><section className="max-h-[calc(100vh-3rem)] w-full max-w-2xl overflow-y-auto rounded-[2rem] border border-white/80 bg-white/95 p-5 shadow-2xl shadow-slate-300/60">
+        <div className="fixed inset-0 z-40 flex items-center justify-center bg-slate-950/15 px-4 backdrop-blur-sm"><section className="w-full max-w-2xl rounded-[2rem] border border-white/80 bg-white/95 p-5 shadow-2xl shadow-slate-300/60">
           <h2 className="text-2xl font-semibold text-slate-950">{editingNode.id === 'me' ? '编辑中心节点' : '编辑生活节点'}</h2>
           <div className="mt-4 grid gap-4 md:grid-cols-2">
             <label className="text-sm font-medium text-slate-600">{editingNode.id === 'me' ? '昵称' : '节点名称'}<input value={editingNode.data?.title ?? ''} onChange={(event) => setEditingNode({ ...editingNode, data: { ...getLifeMapData(editingNode), title: event.target.value } })} className="mt-2 w-full rounded-2xl border border-slate-200 px-4 py-3" /></label>

--- a/src/components/LifeOSNav.tsx
+++ b/src/components/LifeOSNav.tsx
@@ -7,6 +7,7 @@ interface LifeOSNavProps {
 
 const navItems: { id: LifeOSModule; label: string }[] = [
   { id: 'home', label: '首页' },
+  { id: 'task', label: '任务' },
   { id: 'map', label: '地图' },
   { id: 'social', label: '社交' },
   { id: 'log', label: '日志' },
@@ -15,13 +16,13 @@ const navItems: { id: LifeOSModule; label: string }[] = [
 
 export function LifeOSNav({ activeModule, onModuleChange }: LifeOSNavProps) {
   return (
-    <nav className="sticky top-3 z-30 rounded-[1.75rem] border border-white/70 bg-white/80 p-2 shadow-xl shadow-slate-200/60 backdrop-blur md:top-4" aria-label="LifeOS modules">
+    <nav className="sticky top-3 z-30 rounded-[1.75rem] border border-white/70 bg-white/80 p-2 shadow-xl shadow-slate-200/60 backdrop-blur md:top-4" aria-label="LifeOS 模块">
       <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
         <div className="px-3 py-1.5">
           <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-400">LifeOS</p>
-          <p className="mt-1 text-sm font-medium text-slate-600">Personal operating system</p>
+          <p className="mt-1 text-sm font-medium text-slate-600">个人操作系统</p>
         </div>
-        <div className="grid grid-cols-5 gap-1 rounded-[1.35rem] bg-slate-100/70 p-1 sm:flex sm:flex-wrap">
+        <div className="grid grid-cols-6 gap-1 rounded-[1.35rem] bg-slate-100/70 p-1 sm:flex sm:flex-wrap">
           {navItems.map((item) => {
             const isActive = activeModule === item.id;
             return (

--- a/src/components/LogPage.tsx
+++ b/src/components/LogPage.tsx
@@ -11,7 +11,7 @@ export function LogPage({ tasks, onDelete, onReviewNoteChange }: LogPageProps) {
   return (
     <section className="space-y-6">
       <div className="rounded-[2rem] border border-white/70 bg-white/75 p-6 shadow-xl shadow-slate-200/60 backdrop-blur">
-        <p className="text-sm font-semibold uppercase tracking-[0.24em] text-slate-400">Log</p>
+        <p className="text-sm font-semibold tracking-[0.24em] text-slate-400">日志</p>
         <h1 className="mt-2 text-4xl font-semibold tracking-tight text-slate-950">日志</h1>
         <p className="mt-3 max-w-2xl text-sm leading-6 text-slate-500">完成与放弃的项目会在这里形成更完整的本地记录，用于复盘节奏，而不是制造压力。</p>
       </div>

--- a/src/components/MiniTaskMatrix.tsx
+++ b/src/components/MiniTaskMatrix.tsx
@@ -1,0 +1,70 @@
+import type { Task } from '../types/task';
+import { formatCountdown } from '../utils/date';
+import { getImportancePosition, getTaskScore, getUrgencyPosition } from '../utils/taskScoring';
+
+interface MiniTaskMatrixProps {
+  tasks: Task[];
+  onOpenTasks: () => void;
+}
+
+function pointTone(task: Task): string {
+  const urgent = getUrgencyPosition(task.deadline) >= 66;
+  if (task.importance >= 8 && urgent) return 'bg-rose-400 shadow-rose-100';
+  if (task.importance >= 8) return 'bg-amber-400 shadow-amber-100';
+  if (urgent) return 'bg-sky-400 shadow-sky-100';
+  return 'bg-slate-400 shadow-slate-100';
+}
+
+export function MiniTaskMatrix({ tasks, onOpenTasks }: MiniTaskMatrixProps) {
+  const visibleTasks = [...tasks]
+    .sort((a, b) => getTaskScore(b) - getTaskScore(a))
+    .slice(0, 6);
+
+  return (
+    <section className="rounded-[2rem] border border-white/70 bg-white/75 p-4 shadow-xl shadow-slate-200/60 backdrop-blur md:p-5">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <p className="text-sm font-semibold text-slate-500">当前任务热区</p>
+          <h2 className="mt-1 text-2xl font-semibold tracking-tight text-slate-950">重要性 × 截止压力</h2>
+        </div>
+        <button type="button" onClick={onOpenTasks} className="rounded-full bg-white/85 px-4 py-2 text-xs font-semibold text-slate-600 shadow-sm ring-1 ring-slate-200 hover:bg-slate-50">
+          进入任务页
+        </button>
+      </div>
+
+      <button type="button" onClick={onOpenTasks} className="mt-4 block w-full text-left" aria-label="打开完整任务系统">
+        <div className="relative h-56 overflow-hidden rounded-[1.5rem] border border-slate-200 bg-gradient-to-br from-white via-slate-50 to-sky-50/70 p-4 shadow-inner">
+          <div className="pointer-events-none absolute inset-8 border border-slate-300/80 bg-[linear-gradient(90deg,rgba(148,163,184,0.10)_1px,transparent_1px),linear-gradient(0deg,rgba(148,163,184,0.10)_1px,transparent_1px)] bg-[size:25%_25%]" />
+          <div className="pointer-events-none absolute left-8 right-8 top-1/2 border-t border-slate-300/90" />
+          <div className="pointer-events-none absolute bottom-8 left-1/2 top-8 border-l border-slate-300/90" />
+          <div className="pointer-events-none absolute right-10 top-9 rounded-full bg-rose-50/90 px-2.5 py-1 text-[11px] font-semibold text-rose-600">紧急且重要</div>
+          <div className="pointer-events-none absolute left-10 top-9 rounded-full bg-sky-50/90 px-2.5 py-1 text-[11px] font-semibold text-sky-600">重要不紧急</div>
+          <div className="pointer-events-none absolute bottom-9 right-10 rounded-full bg-amber-50/90 px-2.5 py-1 text-[11px] font-semibold text-amber-600">截止压力</div>
+          <div className="pointer-events-none absolute bottom-9 left-10 rounded-full bg-white/80 px-2.5 py-1 text-[11px] font-semibold text-slate-400">低负荷</div>
+
+          {visibleTasks.length === 0 ? (
+            <div className="absolute inset-0 flex items-center justify-center text-sm font-medium text-slate-400">添加任务后，这里会显示今日热区。</div>
+          ) : null}
+
+          {visibleTasks.map((task) => {
+            const left = Math.min(88, Math.max(12, getUrgencyPosition(task.deadline)));
+            const bottom = Math.min(86, Math.max(14, getImportancePosition(task.importance)));
+            return (
+              <div key={task.id} className="absolute -translate-x-1/2 translate-y-1/2" style={{ left: `${left}%`, bottom: `${bottom}%` }}>
+                <span className={`block h-4 w-4 rounded-full border-2 border-white shadow-md ${pointTone(task)}`} />
+                <span className={`absolute top-1/2 max-w-24 -translate-y-1/2 truncate rounded-full bg-white/90 px-2 py-0.5 text-[11px] font-medium text-slate-600 shadow-sm ring-1 ring-white/80 ${left > 68 ? 'right-5' : 'left-5'}`}>
+                  {task.title}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      </button>
+
+      <div className="mt-3 flex flex-wrap items-center justify-between gap-2 text-xs text-slate-500">
+        <span>只展示最相关的 {visibleTasks.length} 项；完整象限、详情与操作在任务页。</span>
+        {visibleTasks[0] ? <span className="rounded-full bg-slate-50 px-2.5 py-1 ring-1 ring-white/80">最高优先：{visibleTasks[0].title} · {formatCountdown(visibleTasks[0].deadline)}</span> : null}
+      </div>
+    </section>
+  );
+}

--- a/src/components/ProfilePage.tsx
+++ b/src/components/ProfilePage.tsx
@@ -8,19 +8,19 @@ interface ProfilePageProps {
 }
 
 const profileFields: { key: keyof UserProfile; label: string; placeholder: string; multiline?: boolean }[] = [
-  { key: 'nickname', label: 'nickname', placeholder: '你希望 LifeOS 如何称呼你' },
-  { key: 'height', label: 'height', placeholder: '例如：175 cm' },
-  { key: 'weight', label: 'weight', placeholder: '例如：68 kg' },
-  { key: 'identity', label: 'identity', placeholder: '例如：学生 / 研究者 / 创作者' },
-  { key: 'skills', label: 'skills', placeholder: '写下你正在积累的能力', multiline: true },
-  { key: 'longTermGoals', label: 'longTermGoals', placeholder: '写下长期目标，不需要完美', multiline: true },
-  { key: 'currentStage', label: 'currentStage', placeholder: '描述当前人生阶段与主要节奏', multiline: true },
+  { key: 'nickname', label: '昵称', placeholder: '你希望 LifeOS 如何称呼你' },
+  { key: 'height', label: '身高', placeholder: '例如：175 cm' },
+  { key: 'weight', label: '体重', placeholder: '例如：68 kg' },
+  { key: 'identity', label: '身份', placeholder: '例如：学生 / 研究者 / 创作者' },
+  { key: 'skills', label: '能力', placeholder: '写下你正在积累的能力', multiline: true },
+  { key: 'longTermGoals', label: '长期目标', placeholder: '写下长期目标，不需要完美', multiline: true },
+  { key: 'currentStage', label: '当前阶段', placeholder: '描述当前人生阶段与主要节奏', multiline: true },
 ];
 
 const systemItems = [
-  { title: 'Local-only mode', description: '当前数据保存在本机浏览器；未来云同步会作为可选能力。' },
-  { title: 'Privacy policy', description: '隐私政策与数据边界预留入口，当前版本不上传个人数据。' },
-  { title: 'Future sync', description: '为账号、认证和多设备同步保留结构，但不启用后端。' },
+  { title: '本地模式', description: '当前数据保存在本机浏览器；未来云同步会作为可选能力。' },
+  { title: '隐私说明', description: '隐私政策与数据边界预留入口，当前版本不上传个人数据。' },
+  { title: '未来同步', description: '为账号、认证和多设备同步保留结构，但不启用后端。' },
 ];
 
 export function ProfilePage({ profile, onProfileChange }: ProfilePageProps) {
@@ -40,10 +40,10 @@ export function ProfilePage({ profile, onProfileChange }: ProfilePageProps) {
       <div className="rounded-[2rem] border border-white/70 bg-white/75 p-6 shadow-xl shadow-slate-200/60 backdrop-blur">
       <div className="flex flex-wrap items-center gap-5">
         <div className="flex h-28 w-28 items-center justify-center overflow-hidden rounded-[2rem] bg-slate-100 text-4xl font-semibold text-slate-400 shadow-inner ring-1 ring-white/80">
-          {profile.avatarDataUrl ? <img src={profile.avatarDataUrl} alt="Profile avatar" className="h-full w-full object-cover" /> : (profile.nickname || '我').slice(0, 1)}
+          {profile.avatarDataUrl ? <img src={profile.avatarDataUrl} alt="个人头像" className="h-full w-full object-cover" /> : (profile.nickname || '我').slice(0, 1)}
         </div>
         <div className="min-w-0 flex-1">
-          <p className="text-sm font-semibold uppercase tracking-[0.24em] text-slate-400">Me · System Settings</p>
+          <p className="text-sm font-semibold uppercase tracking-[0.24em] text-slate-400">我 · 系统设置</p>
           <h1 className="mt-2 text-4xl font-semibold tracking-tight text-slate-950">我</h1>
           <p className="mt-3 max-w-2xl text-sm leading-6 text-slate-500">个人资料、系统状态与数据安全都放在这里。当前信息只保存在当前浏览器的 VD 存储层中。</p>
           <label className="mt-4 inline-flex cursor-pointer rounded-full bg-slate-950 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-slate-700">
@@ -88,7 +88,7 @@ export function ProfilePage({ profile, onProfileChange }: ProfilePageProps) {
             </article>
           ))}
         </div>
-        <p className="mt-4 rounded-2xl bg-white/75 px-4 py-3 text-xs leading-5 text-slate-500 ring-1 ring-white/80">App version v0.9 foundation · Web-first · PWA-ready layout placeholder</p>
+        <p className="mt-4 rounded-2xl bg-white/75 px-4 py-3 text-xs leading-5 text-slate-500 ring-1 ring-white/80">应用版本 v0.9 基础版 · 网页优先 · 渐进式应用布局预留</p>
       </section>
 
       <DataSafetyPanel />

--- a/src/components/SocialPage.tsx
+++ b/src/components/SocialPage.tsx
@@ -4,14 +4,13 @@ import { useLocalStorage } from '../hooks/useLocalStorage';
 import { storageKeys } from '../storage';
 import type { SocialPersonData } from '../types/task';
 
-const CURRENT_SOCIAL_LAYOUT_VERSION = 6;
+const CURRENT_SOCIAL_LAYOUT_VERSION = 7;
 const CENTER = { x: 720, y: 560 };
 const DEFAULT_PERSON_COLOR = '#d8e2dc';
 const CENTER_NODE_COLOR = '#1e293b';
 const MAX_SOCIAL_DISTANCE = 1400;
 const NODE_WIDTH = 132;
 const NODE_HEIGHT = 62;
-const MIN_NODE_GAP = 118;
 
 type SocialNode = Node<SocialPersonData>;
 type LegacySocialData = Partial<SocialPersonData> & { details?: string; nickname?: string };
@@ -63,16 +62,6 @@ function isValidSocialPosition(position: unknown): position is SocialNode['posit
   return Math.hypot(candidate.x + NODE_WIDTH / 2 - CENTER.x, candidate.y + NODE_HEIGHT / 2 - CENTER.y) <= MAX_SOCIAL_DISTANCE;
 }
 
-function daysSince(date: string): number {
-  if (!date) return 365;
-  const timestamp = new Date(date).getTime();
-  if (!Number.isFinite(timestamp)) return 365;
-  return Math.max(0, Math.floor((Date.now() - timestamp) / 86400000));
-}
-
-function recencyScore(date: string): number {
-  return Math.max(0, 100 - Math.min(180, daysSince(date)) * 0.55);
-}
 
 function clusterFor(data: Partial<SocialPersonData>) {
   const source = `${data.roleCategory ?? ''} ${data.relationshipType ?? ''}`.toLowerCase();
@@ -86,53 +75,29 @@ function normalizeRoleCategory(data?: LegacySocialData): string {
 }
 
 function relationshipStrength(data: SocialPersonData): number {
-  return Math.round(
-    clampScore(data.subjectiveFavorability) * 0.2 +
-    clampScore(data.familiarity) * 0.18 +
-    clampScore(data.trust) * 0.2 +
-    clampScore(data.interactionFrequency) * 0.14 +
-    recencyScore(data.lastInteractionDate) * 0.1 +
-    clampScore(data.emotionalCloseness) * 0.13 +
-    clampScore(data.influenceWeight) * 0.05,
-  );
+  return clampScore(data.subjectiveFavorability);
+}
+
+function socialRing(score: number): { label: string; radius: number } {
+  if (score >= 80) return { label: '核心圈', radius: 180 };
+  if (score >= 60) return { label: '亲近圈', radius: 300 };
+  if (score >= 40) return { label: '熟悉圈', radius: 420 };
+  if (score >= 20) return { label: '普通圈', radius: 540 };
+  return { label: '外围圈', radius: 660 };
 }
 
 function targetPosition(node: SocialNode, index: number): SocialNode['position'] {
   const data = node.data ?? normalizeSocialData(undefined);
   const cluster = socialClusters.find((item) => item.id === data.cluster) ?? clusterFor(data);
-  const strength = relationshipStrength(data);
-  const influence = clampScore(data.influenceWeight);
-  const radius = 170 + (1 - strength / 100) * 560 - influence * 0.55 + (index % 4) * 16;
-  const angle = normalizeAngle(data.angle) ?? cluster.angle + stableOffset(node.id, 0.72);
+  const score = clampScore(data.subjectiveFavorability);
+  const radius = socialRing(score).radius;
+  const angle = normalizeAngle(data.angle) ?? cluster.angle + stableOffset(node.id, 0.56) + (index % 3 - 1) * 0.08;
   return {
     x: Math.round(CENTER.x + Math.cos(angle) * radius - NODE_WIDTH / 2),
     y: Math.round(CENTER.y + Math.sin(angle) * radius - NODE_HEIGHT / 2),
   };
 }
 
-function relaxCollisions(nodes: SocialNode[]): SocialNode[] {
-  const relaxed = nodes.map((node) => ({ ...node, position: { ...node.position } }));
-  for (let iteration = 0; iteration < 34; iteration += 1) {
-    for (let a = 0; a < relaxed.length; a += 1) {
-      for (let b = a + 1; b < relaxed.length; b += 1) {
-        const left = relaxed[a];
-        const right = relaxed[b];
-        const dx = right.position.x - left.position.x;
-        const dy = right.position.y - left.position.y;
-        const distance = Math.max(1, Math.hypot(dx, dy));
-        if (distance >= MIN_NODE_GAP) continue;
-        const push = (MIN_NODE_GAP - distance) / 2;
-        const ux = dx / distance;
-        const uy = dy / distance;
-        left.position.x = Math.round(left.position.x - ux * push);
-        left.position.y = Math.round(left.position.y - uy * push);
-        right.position.x = Math.round(right.position.x + ux * push);
-        right.position.y = Math.round(right.position.y + uy * push);
-      }
-    }
-  }
-  return relaxed;
-}
 
 function meNode(): SocialNode {
   return {
@@ -183,7 +148,7 @@ function normalizeNodes(nodes: unknown): SocialNode[] {
     const position = data.manualPosition && isValidSocialPosition(node.position) ? node.position : targetPosition({ id: String(node.id), position: { x: 0, y: 0 }, data: { ...data, angle } }, index);
     return { id: String(node.id), position, data: { ...data, angle } };
   });
-  return [meNode(), ...relaxCollisions(prepared)];
+  return [meNode(), ...prepared];
 }
 
 function getSocialData(node: SocialNode): SocialPersonData {
@@ -194,14 +159,7 @@ function buildRelationshipEdges(nodes: SocialNode[]): Edge<{ familiarity: number
   return nodes.filter((node) => node.id !== 'me').map((node) => ({ id: `me-${node.id}`, source: 'me', target: node.id, data: { familiarity: relationshipStrength(getSocialData(node)) } }));
 }
 
-const metricFields: { key: keyof SocialPersonData; label: string }[] = [
-  { key: 'subjectiveFavorability', label: '好感度' },
-  { key: 'familiarity', label: '熟悉度' },
-  { key: 'trust', label: '信任' },
-  { key: 'interactionFrequency', label: '互动频率' },
-  { key: 'emotionalCloseness', label: '情感亲近' },
-  { key: 'influenceWeight', label: '影响权重' },
-];
+const favorabilityField: { key: keyof SocialPersonData; label: string } = { key: 'subjectiveFavorability', label: '好感度' };
 
 export function SocialPage() {
   const [storedNodes, setStoredNodes] = useLocalStorage<SocialNode[]>(storageKeys.socialNodes, seedNodes());
@@ -228,7 +186,8 @@ export function SocialPage() {
         const changedNode = changedNodes.find((item) => item.id === node.id);
         if (!changedNode) return node;
         const angle = angleFromPosition(changedNode.position) ?? node.data?.angle;
-        return { ...node, position: changedNode.position, data: { ...getSocialData(node), angle, manualPosition: true } };
+        const data = { ...getSocialData(node), angle, manualPosition: true };
+        return { ...node, position: targetPosition({ ...node, data }, currentNodes.findIndex((item) => item.id === node.id)), data };
       });
     });
   }
@@ -249,7 +208,7 @@ export function SocialPage() {
   function saveNode() {
     if (!editingNode) return;
     const sanitizedData = getSocialData(editingNode);
-    const sanitizedNode = { ...editingNode, data: sanitizedData, position: editingNode.id === 'me' ? meNode().position : editingNode.position };
+    const sanitizedNode = { ...editingNode, data: sanitizedData, position: editingNode.id === 'me' ? meNode().position : targetPosition({ ...editingNode, data: sanitizedData }, normalizedNodes.findIndex((node) => node.id === editingNode.id)) };
     setStoredNodes((nodes) => normalizeNodes(nodes).map((node) => (node.id === sanitizedNode.id ? sanitizedNode : node)));
     setEditingNode(undefined);
   }
@@ -265,9 +224,9 @@ export function SocialPage() {
       <div className="rounded-[2rem] border border-white/70 bg-white/75 p-6 shadow-xl shadow-slate-200/60 backdrop-blur">
         <div className="flex flex-wrap items-end justify-between gap-4">
           <div>
-            <p className="text-sm font-semibold uppercase tracking-[0.24em] text-slate-400">Social Memory Map · v0.8</p>
+            <p className="text-sm font-semibold tracking-[0.24em] text-slate-400">社交图谱</p>
             <h1 className="mt-2 text-4xl font-semibold tracking-tight text-slate-950">社交</h1>
-            <p className="mt-3 max-w-2xl text-sm leading-6 text-slate-500">多因素嵌入会综合好感、熟悉、信任、互动、亲近与影响力来形成距离和软聚类。</p>
+            <p className="mt-3 max-w-2xl text-sm leading-6 text-slate-500">好感度决定关系距离；拖动联系人只改变围绕“我”的方向。</p>
           </div>
           <button type="button" onClick={addPerson} className="rounded-full bg-slate-950 px-5 py-3 text-sm font-semibold text-white shadow-sm hover:bg-slate-700">添加联系人</button>
         </div>
@@ -277,16 +236,39 @@ export function SocialPage() {
       </div>
 
       <div className="relative h-[72vh] min-h-[560px] overflow-hidden rounded-[2rem] border border-white/70 bg-white/75 p-3 shadow-xl shadow-slate-200/60 backdrop-blur md:min-h-[680px]">
-        <div className="pointer-events-none absolute left-5 top-5 z-10 max-w-md rounded-2xl bg-white/85 px-4 py-3 text-xs leading-5 text-slate-500 shadow-sm ring-1 ring-white/80 backdrop-blur">距离由多因素强度决定；颜色代表自动聚类；拖动节点可固定手动位置。Ctrl/⌘ + 滚轮或按钮缩放。</div>
+        <div className="pointer-events-none absolute left-5 top-5 z-10 max-w-md rounded-2xl bg-white/85 px-4 py-3 text-xs leading-5 text-slate-500 shadow-sm ring-1 ring-white/80 backdrop-blur">好感度决定距离；拖动只改变方向，不改变亲近程度。Ctrl/⌘ + 滚轮或按钮缩放。</div>
         {contacts.length === 0 ? <div className="pointer-events-none absolute inset-x-0 top-24 z-10 text-center text-sm font-medium text-slate-400">添加对你重要的人，构建你的关系地图。</div> : null}
         <ReactFlow nodes={normalizedNodes} edges={relationshipEdges} onNodesChange={handleNodesChange} onNodeClick={(_, node) => setEditingNode(node)} selectedNodeId={editingNode?.id} fitView className="rounded-[1.5rem] bg-slate-50/80"><Background /><Controls /></ReactFlow>
       </div>
 
-      {editingNode ? <div className="fixed inset-0 z-40 flex items-center justify-center bg-slate-950/15 px-4 backdrop-blur-sm"><section className="max-h-[calc(100vh-3rem)] w-full max-w-3xl overflow-y-auto rounded-[2rem] border border-white/80 bg-white/95 p-5 shadow-2xl shadow-slate-300/60"><h2 className="text-2xl font-semibold text-slate-950">{editingNode.id === 'me' ? '编辑中心节点' : '编辑关系'}</h2><p className="mt-2 rounded-2xl bg-slate-50 px-4 py-3 text-xs leading-5 text-slate-500">社交图谱会根据多维指标重新计算软聚类与距离；手动拖动的位置会被保留。</p><div className="mt-4 grid gap-4 md:grid-cols-2">
-        <label className="text-sm font-medium text-slate-600">{editingNode.id === 'me' ? '昵称' : '姓名'}<input value={editingNode.data?.name ?? ''} onChange={(event) => updateEditingData('name', event.target.value)} className="mt-2 w-full rounded-2xl border border-slate-200 px-4 py-3" /></label>
-        {editingNode.id === 'me' ? <><label className="text-sm font-medium text-slate-600">当前社交状态<input value={editingNode.data?.currentSocialState ?? ''} onChange={(event) => updateEditingData('currentSocialState', event.target.value)} className="mt-2 w-full rounded-2xl border border-slate-200 px-4 py-3" /></label><label className="text-sm font-medium text-slate-600 md:col-span-2">简介<textarea value={editingNode.data?.bio ?? ''} onChange={(event) => updateEditingData('bio', event.target.value)} className="mt-2 min-h-24 w-full rounded-2xl border border-slate-200 px-4 py-3" /></label></> : <><label className="text-sm font-medium text-slate-600">关系类型<input value={editingNode.data?.relationshipType ?? ''} onChange={(event) => updateEditingData('relationshipType', event.target.value)} placeholder="朋友、导师、家人……" className="mt-2 w-full rounded-2xl border border-slate-200 px-4 py-3" /></label><label className="text-sm font-medium text-slate-600">角色/分类<input value={editingNode.data?.roleCategory ?? ''} onChange={(event) => updateEditingData('roleCategory', event.target.value)} placeholder="同学、家人、线上朋友……" className="mt-2 w-full rounded-2xl border border-slate-200 px-4 py-3" /></label><label className="text-sm font-medium text-slate-600">最近互动时间<input type="date" value={editingNode.data?.lastInteractionDate ?? ''} onChange={(event) => updateEditingData('lastInteractionDate', event.target.value)} className="mt-2 w-full rounded-2xl border border-slate-200 px-4 py-3" /></label></>}
-        {editingNode.id !== 'me' ? metricFields.map((field) => <label key={field.key} className="text-sm font-medium text-slate-600 md:col-span-2">{field.label}<div className="mt-2 flex items-center gap-3"><input type="range" min="0" max="100" value={clampScore(editingNode.data?.[field.key])} onChange={(event) => updateEditingData(field.key, event.target.value)} className="w-full accent-slate-900" /><input type="number" min="0" max="100" value={clampScore(editingNode.data?.[field.key])} onChange={(event) => updateEditingData(field.key, String(clampScore(event.target.value)))} className="w-24 rounded-2xl border border-slate-200 px-3 py-2" /></div></label>) : null}
-        <label className="text-sm font-medium text-slate-600">节点颜色<input type="color" value={editingNode.data?.color ?? DEFAULT_PERSON_COLOR} onChange={(event) => updateEditingData('color', event.target.value)} className="mt-2 h-12 w-24 rounded-2xl border border-slate-200 bg-white p-1" /></label><label className="text-sm font-medium text-slate-600 md:col-span-2">关系备注<textarea value={editingNode.data?.notes ?? ''} onChange={(event) => updateEditingData('notes', event.target.value)} placeholder="记忆、互动提醒、情绪观察、共同话题、未来跟进……" className="mt-2 min-h-28 w-full rounded-2xl border border-slate-200 px-4 py-3" /></label></div><div className="mt-6 flex flex-wrap justify-between gap-3"><button type="button" disabled={editingNode.id === 'me'} onClick={deleteNode} className="rounded-full px-4 py-2 text-sm font-semibold text-rose-500 hover:bg-rose-50 disabled:cursor-not-allowed disabled:text-slate-300">删除</button><div className="flex gap-3"><button type="button" onClick={() => setEditingNode(undefined)} className="rounded-full px-4 py-2 text-sm font-semibold text-slate-500 hover:bg-slate-100">取消</button><button type="button" onClick={saveNode} className="rounded-full bg-slate-950 px-5 py-2 text-sm font-semibold text-white">保存</button></div></div></section></div> : null}
+      {editingNode ? (
+        <div className="fixed inset-0 z-40 flex items-center justify-center bg-slate-950/15 px-4 backdrop-blur-sm">
+          <section className="w-full max-w-2xl rounded-[2rem] border border-white/80 bg-white/95 p-5 shadow-2xl shadow-slate-300/60">
+            <h2 className="text-2xl font-semibold text-slate-950">{editingNode.id === 'me' ? '编辑中心节点' : '编辑关系'}</h2>
+            <p className="mt-2 rounded-2xl bg-slate-50 px-4 py-3 text-xs leading-5 text-slate-500">表单只保留当前最必要的信息；旧数据中的熟悉度、信任等字段会继续保留在本地存储中。</p>
+            <div className="mt-4 grid gap-4 md:grid-cols-2">
+              <label className="text-sm font-medium text-slate-600">
+                {editingNode.id === 'me' ? '昵称' : '姓名'}
+                <input value={editingNode.data?.name ?? ''} onChange={(event) => updateEditingData('name', event.target.value)} className="mt-2 w-full rounded-2xl border border-slate-200 px-4 py-3" />
+              </label>
+              {editingNode.id === 'me' ? (
+                <>
+                  <label className="text-sm font-medium text-slate-600">当前社交状态<input value={editingNode.data?.currentSocialState ?? ''} onChange={(event) => updateEditingData('currentSocialState', event.target.value)} className="mt-2 w-full rounded-2xl border border-slate-200 px-4 py-3" /></label>
+                  <label className="text-sm font-medium text-slate-600 md:col-span-2">简介<textarea value={editingNode.data?.bio ?? ''} onChange={(event) => updateEditingData('bio', event.target.value)} className="mt-2 min-h-24 w-full rounded-2xl border border-slate-200 px-4 py-3" /></label>
+                </>
+              ) : (
+                <>
+                  <label className="text-sm font-medium text-slate-600">角色/分类<input value={editingNode.data?.roleCategory ?? ''} onChange={(event) => updateEditingData('roleCategory', event.target.value)} placeholder="同学、家人、线上朋友……" className="mt-2 w-full rounded-2xl border border-slate-200 px-4 py-3" /></label>
+                  <label className="text-sm font-medium text-slate-600 md:col-span-2">{favorabilityField.label}<div className="mt-2 flex items-center gap-3"><input type="range" min="0" max="100" value={clampScore(editingNode.data?.[favorabilityField.key])} onChange={(event) => updateEditingData(favorabilityField.key, event.target.value)} className="w-full accent-slate-900" /><input type="number" min="0" max="100" value={clampScore(editingNode.data?.[favorabilityField.key])} onChange={(event) => updateEditingData(favorabilityField.key, String(clampScore(event.target.value)))} className="w-24 rounded-2xl border border-slate-200 px-3 py-2" /></div><p className="mt-2 text-xs text-slate-400">{socialRing(clampScore(editingNode.data?.subjectiveFavorability)).label}</p></label>
+                </>
+              )}
+              <label className="text-sm font-medium text-slate-600">节点颜色<input type="color" value={editingNode.data?.color ?? DEFAULT_PERSON_COLOR} onChange={(event) => updateEditingData('color', event.target.value)} className="mt-2 h-12 w-24 rounded-2xl border border-slate-200 bg-white p-1" /></label>
+              <label className="text-sm font-medium text-slate-600 md:col-span-2">关系备注<textarea value={editingNode.data?.notes ?? ''} onChange={(event) => updateEditingData('notes', event.target.value)} placeholder="记忆、互动提醒、共同话题、未来跟进……" className="mt-2 min-h-24 w-full rounded-2xl border border-slate-200 px-4 py-3" /></label>
+            </div>
+            <div className="mt-6 flex flex-wrap justify-between gap-3"><button type="button" disabled={editingNode.id === 'me'} onClick={deleteNode} className="rounded-full px-4 py-2 text-sm font-semibold text-rose-500 hover:bg-rose-50 disabled:cursor-not-allowed disabled:text-slate-300">删除</button><div className="flex gap-3"><button type="button" onClick={() => setEditingNode(undefined)} className="rounded-full px-4 py-2 text-sm font-semibold text-slate-500 hover:bg-slate-100">取消</button><button type="button" onClick={saveNode} className="rounded-full bg-slate-950 px-5 py-2 text-sm font-semibold text-white">保存</button></div></div>
+          </section>
+        </div>
+      ) : null}
     </section>
   );
 }

--- a/src/components/TaskPage.tsx
+++ b/src/components/TaskPage.tsx
@@ -1,0 +1,34 @@
+import type { LifecycleStatus, Task, Achievement } from '../types/task';
+import { AchievementsPanel } from './AchievementsPanel';
+import { PriorityMap } from './PriorityMap';
+import { TaskList } from './TaskList';
+
+interface TaskPageProps {
+  activeTasks: Task[];
+  achievements: Achievement[];
+  onAddTask: () => void;
+  onArchiveTask: (task: Task, lifecycleStatus: Exclude<LifecycleStatus, 'active'>) => void;
+  onDeleteTask: (taskId: string) => void;
+  onEditTask: (task: Task) => void;
+}
+
+export function TaskPage({ activeTasks, achievements, onAddTask, onArchiveTask, onDeleteTask, onEditTask }: TaskPageProps) {
+  return (
+    <section className="space-y-6">
+      <header className="flex flex-wrap items-center justify-between gap-4 rounded-[2rem] border border-white/70 bg-white/75 p-6 shadow-xl shadow-slate-200/60 backdrop-blur">
+        <div>
+          <p className="text-sm font-semibold tracking-[0.24em] text-slate-500">任务系统</p>
+          <h1 className="mt-2 text-4xl font-semibold tracking-tight text-slate-950 md:text-5xl">任务</h1>
+          <p className="mt-3 max-w-2xl text-slate-600">完整任务操作中心：先看紧急重要矩阵，再处理进行中的项目。</p>
+        </div>
+        <button type="button" onClick={onAddTask} className="rounded-full bg-slate-950 px-6 py-3 text-sm font-semibold text-white shadow-lg shadow-slate-900/10 hover:bg-slate-700">
+          添加项目
+        </button>
+      </header>
+
+      <PriorityMap tasks={activeTasks} />
+      <TaskList tasks={activeTasks} onArchive={onArchiveTask} onDelete={onDeleteTask} onEdit={onEditTask} />
+      <AchievementsPanel achievements={achievements} />
+    </section>
+  );
+}

--- a/src/types/task.ts
+++ b/src/types/task.ts
@@ -70,7 +70,7 @@ export interface Achievement {
   unlockedAt: string;
 }
 
-export type LifeOSModule = 'home' | 'map' | 'social' | 'log' | 'me';
+export type LifeOSModule = 'home' | 'task' | 'map' | 'social' | 'log' | 'me';
 
 export interface UserProfile {
   nickname: string;

--- a/src/vendor/xyflow-react/index.js
+++ b/src/vendor/xyflow-react/index.js
@@ -35,6 +35,44 @@ export function Controls() {
   }, 'Ctrl/⌘ + 滚轮缩放 · 按钮缩放 · 拖动画布/节点');
 }
 
+
+function softenColor(color) {
+  if (typeof color !== 'string' || !/^#[0-9a-fA-F]{6}$/.test(color)) return color || '#e2e8f0';
+  const amount = 0.72;
+  const r = parseInt(color.slice(1, 3), 16);
+  const g = parseInt(color.slice(3, 5), 16);
+  const b = parseInt(color.slice(5, 7), 16);
+  const mix = (value) => Math.round(value + (255 - value) * amount).toString(16).padStart(2, '0');
+  return `#${mix(r)}${mix(g)}${mix(b)}`;
+}
+
+function nodeVisual(node) {
+  const isCenter = node.id === 'me';
+  const isLife = node.type === 'life';
+  const softColor = softenColor(node.data?.color);
+  if (isCenter) {
+    return {
+      className: isLife ? 'border-slate-300 bg-white/95 text-slate-950 ring-slate-200' : 'border-slate-500 text-white ring-slate-300',
+      style: { backgroundColor: isLife ? '#ffffff' : '#1e293b', borderColor: isLife ? '#cbd5e1' : '#0f172a', color: isLife ? '#0f172a' : '#f8fafc' },
+      badgeStyle: { backgroundColor: isLife ? '#e2e8f0' : '#f8fafc', color: '#0f172a' },
+      titleColor: isLife ? '#020617' : '#f8fafc',
+      subtitleColor: isLife ? '#64748b' : '#cbd5e1',
+    };
+  }
+  return {
+    className: 'border-white/80 bg-white/95 text-slate-950 ring-white/80',
+    style: { borderColor: softColor, color: '#020617' },
+    badgeStyle: { backgroundColor: softColor, color: '#0f172a' },
+    titleColor: '#020617',
+    subtitleColor: '#64748b',
+  };
+}
+
+function orthogonalPath(x1, y1, x2, y2) {
+  const midY = Math.round((y1 + y2) / 2);
+  return `M ${x1} ${y1} V ${midY} H ${x2} V ${y2}`;
+}
+
 function isReasonablePosition(position) {
   return Number.isFinite(position?.x) && Number.isFinite(position?.y) && Math.abs(position.x) < 10000 && Math.abs(position.y) < 10000;
 }
@@ -203,10 +241,13 @@ export function ReactFlow({ nodes = [], edges = [], onNodesChange, onNodeClick, 
           const familiarity = Math.min(100, Math.max(0, Number(edge.data?.familiarity ?? 50)));
           const opacity = 0.22 + familiarity / 220;
           const strokeWidth = 1 + familiarity / 60;
+          if (edge.data?.route === 'orthogonal') return React.createElement('path', { key: edge.id, d: orthogonalPath(x1, y1, x2, y2), fill: 'none', stroke: `rgba(100,116,139,${opacity})`, strokeWidth, strokeLinecap: 'round', strokeLinejoin: 'round' });
           return React.createElement('line', { key: edge.id, x1, y1, x2, y2, stroke: `rgba(100,116,139,${opacity})`, strokeWidth, strokeLinecap: 'round' });
         }),
       ),
-      nodes.map((node) => React.createElement('button', {
+      nodes.map((node) => {
+        const visual = nodeVisual(node);
+        return React.createElement('button', {
         key: node.id,
         type: 'button',
         onClick: (event) => {
@@ -232,15 +273,16 @@ export function ReactFlow({ nodes = [], edges = [], onNodesChange, onNodeClick, 
         },
         onPointerUp: () => { setDocumentDragging(false); setDraggingId(null); },
         onPointerCancel: () => { setDocumentDragging(false); setDraggingId(null); },
-        className: `absolute flex w-[8.25rem] cursor-grab select-none items-center gap-2 rounded-2xl border bg-white/95 px-2.5 py-2 text-left shadow-lg shadow-slate-200/60 ring-1 backdrop-blur transition hover:-translate-y-0.5 hover:shadow-xl active:cursor-grabbing ${selectedNodeId === node.id ? 'ring-2 ring-slate-400' : ''} ${node.id === 'me' ? 'border-slate-500 text-white ring-slate-300' : 'border-white/80 text-slate-950 ring-white/80'}`,
-        style: { left: node.position.x, top: node.position.y, backgroundColor: node.id === 'me' ? '#1e293b' : undefined, borderColor: node.id === 'me' ? '#0f172a' : node.data?.color ?? undefined, color: node.id === 'me' ? '#f8fafc' : undefined, userSelect: 'none', WebkitUserSelect: 'none', touchAction: 'none' },
+        className: `absolute flex w-[8.25rem] cursor-grab select-none items-center gap-2 rounded-2xl border px-2.5 py-2 text-left shadow-lg shadow-slate-200/60 ring-1 backdrop-blur transition hover:-translate-y-0.5 hover:shadow-xl active:cursor-grabbing ${selectedNodeId === node.id ? 'ring-2 ring-slate-400' : ''} ${visual.className}`,
+        style: { left: node.position.x, top: node.position.y, ...visual.style, userSelect: 'none', WebkitUserSelect: 'none', touchAction: 'none' },
       },
-        React.createElement('span', { className: 'flex h-8 w-8 shrink-0 items-center justify-center rounded-xl text-xs font-bold shadow-inner', style: { backgroundColor: node.id === 'me' ? '#f8fafc' : node.data?.color ?? '#e2e8f0', color: node.id === 'me' ? '#0f172a' : '#0f172a' } }, node.data?.avatarInitial || (node.data?.name || node.data?.label || node.data?.title || '未').slice(0, 1)),
+        React.createElement('span', { className: 'flex h-8 w-8 shrink-0 items-center justify-center rounded-xl text-xs font-bold shadow-inner', style: visual.badgeStyle }, node.data?.avatarInitial || (node.data?.name || node.data?.label || node.data?.title || '未').slice(0, 1)),
         React.createElement('span', { className: 'min-w-0 flex-1' },
-          React.createElement('span', { className: 'block truncate text-sm font-semibold', style: { color: node.id === 'me' ? '#f8fafc' : '#020617' } }, node.data?.name || node.data?.label || node.data?.title || '未命名联系人'),
-          node.data?.relationshipType ? React.createElement('span', { className: 'mt-0.5 block truncate text-[11px]', style: { color: node.id === 'me' ? '#cbd5e1' : '#64748b' } }, node.data.roleCategory || node.data.relationshipType) : node.data?.description ? React.createElement('span', { className: 'mt-0.5 block truncate text-[11px]', style: { color: '#64748b' } }, node.data.description) : null,
+          React.createElement('span', { className: 'block truncate text-sm font-semibold', style: { color: visual.titleColor } }, node.data?.name || node.data?.label || node.data?.title || '未命名联系人'),
+          node.data?.relationshipType ? React.createElement('span', { className: 'mt-0.5 block truncate text-[11px]', style: { color: visual.subtitleColor } }, node.data.roleCategory || node.data.relationshipType) : node.data?.description ? React.createElement('span', { className: 'mt-0.5 block truncate text-[11px]', style: { color: '#64748b' } }, node.data.description) : null,
         ),
-      )),
+      );
+      }),
     ),
   );
 }


### PR DESCRIPTION
### Motivation
- Separate the full task management surface from the home/dashboard to make the home page lighter and provide a focused Task page for priority matrix and task list operations.
- Simplify and localize UI copy into Chinese and reduce surface area of certain forms to prioritize the most relevant fields.
- Improve life-map and social-map layouts and visuals for clearer structure and deterministic placement of nodes.

### Description
- Added a new `TaskPage` component and a compact `MiniTaskMatrix` component, and wired them into `App.tsx` so the home page shows the mini matrix while a dedicated `task` module hosts the full task manager.
- Updated `App.tsx` to open the new `task` module from the home page, moved task manager UI into `TaskPage`, and adjusted task form overlay behavior accordingly.
- Introduced layout changes to `LifeMapPage` (layout version bump to 4) implementing a tree/grid positioning strategy, deterministic seeding, collision avoidance, and updated seed colors and copy.
- Simplified social map logic in `SocialPage` (layout version bump to 7) to derive distance from `subjectiveFavorability`, removed complex multi-factor scoring, updated target positioning, UI copy, and the edit form to surface only key fields.
- Localized and adjusted copy and labels across components (`HomePage`, `LifeOSNav`, `LogPage`, `ProfilePage`, `DataSafetyPanel`, `AchievementsPanel`) and updated profile field labels.
- Expanded `LifeOSModule` union in types to include the new `'task'` module.
- Added `MiniTaskMatrix.tsx` to show a condensed importance×deadline matrix and quick entry into the task page.
- Updated vendor `xyflow-react` to improve node visuals, add softened node colors, orthogonal edge paths for life-map edges, and more robust rendering of node/button visuals and badges.

### Testing
- Ran TypeScript type check with `tsc --noEmit`, which completed successfully.
- Performed a production build with `npm run build`, which succeeded locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02f99185d8832ca4d01e501a608c76)