### PR TITLE
Fix onboarding pressure persistence pipeline

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import type { Achievement, AIArtifact, AIArtifactInput, ActivityType, Goal, Goal
 import {
   achievementCatalog,
   calculatePressureIndex,
+  calculateTaskLoad,
   createPressureCalibration,
   clampImportance,
   clampPressure,
@@ -27,7 +28,7 @@ import {
   normalizeProgressMode,
 } from './utils/taskScoring';
 import { appendPressureHistoryRecord, createPressureHistoryRecord, normalizePressureHistory } from './utils/pressureHistory';
-import { hasValue, loadValue, savePressure, saveValue, storageKeys } from './storage';
+import { hasValue, loadValue, savePressure, saveTasks, saveValue, storageKeys } from './storage';
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 const WELCOME_BACK_GAP_MS = 2 * 60 * 60 * 1000;
@@ -343,7 +344,9 @@ function App() {
   const [editingTask, setEditingTask] = useState<Task | undefined>();
   const [toastAchievement, setToastAchievement] = useState<Achievement | undefined>();
   const [welcomeBackMessage, setWelcomeBackMessage] = useState<WelcomeBackMessage | undefined>();
+  const [pressureClock, setPressureClock] = useState(() => Date.now());
   const hasCheckedWelcomeBack = useRef(false);
+  const hasLoggedHydration = useRef(false);
 
   const normalizedTasks = useMemo(() => {
     const storedTasks = Array.isArray(tasks) ? tasks : [];
@@ -358,11 +361,28 @@ function App() {
   const activeTasks = useMemo(() => normalizedTasks.filter((task) => task.lifecycleStatus === 'active'), [normalizedTasks]);
   const recommendedTasks = useMemo(() => normalizedTasks.filter((task) => task.lifecycleStatus === 'active').sort((a, b) => getTaskScore(b) - getTaskScore(a)).slice(0, 3), [normalizedTasks]);
   const deadlinePressureTasks = useMemo(() => activeTasks.filter(isDeadlinePressureTask).sort((a, b) => getTaskScore(b) - getTaskScore(a)), [activeTasks]);
-  const pressure = useMemo<PressureBreakdown>(() => calculatePressureIndex(normalizedTasks, normalizedPressureCalibration, legacyReferencePressure), [normalizedTasks, normalizedPressureCalibration, legacyReferencePressure]);
+  const pressure = useMemo<PressureBreakdown>(() => calculatePressureIndex(normalizedTasks, normalizedPressureCalibration, legacyReferencePressure, new Date(pressureClock)), [normalizedTasks, normalizedPressureCalibration, legacyReferencePressure, pressureClock]);
   const recalibrationPreview = useMemo<PressureBreakdown>(() => {
     const previewCalibration = createPressureCalibration(recalibrationPressure, normalizedTasks, 0, new Date().toISOString());
     return calculatePressureIndex(normalizedTasks, previewCalibration, legacyReferencePressure);
   }, [legacyReferencePressure, normalizedTasks, recalibrationPressure]);
+
+  useEffect(() => {
+    const intervalId = window.setInterval(() => setPressureClock(Date.now()), 60 * 1000);
+    return () => window.clearInterval(intervalId);
+  }, []);
+
+  useEffect(() => {
+    if (hasLoggedHydration.current) return;
+    hasLoggedHydration.current = true;
+    console.info('[VD_ONBOARDING] hydration/restored state after reload', {
+      taskCount: normalizedTasks.length,
+      onboardingComplete,
+      subjectivePressure: normalizedPressureCalibration.lastSubjectivePressure,
+      pressureCoefficient: normalizedPressureCalibration.pressureCoefficient,
+      realtimePressure: pressure.rawPressure,
+    });
+  }, [normalizedPressureCalibration.lastSubjectivePressure, normalizedPressureCalibration.pressureCoefficient, normalizedTasks.length, onboardingComplete, pressure.rawPressure]);
 
   useEffect(() => {
     if (JSON.stringify(tasks) !== JSON.stringify(normalizedTasks)) {
@@ -553,16 +573,90 @@ function App() {
     setIsRecalibrationOpen(false);
   }
 
-  function completeOnboarding(importedTasks: TaskInput[], referencePressure: number, _calibration: PressureCalibrationSnapshot) {
-    const createdTasks = importedTasks.map((task) => createTask(task));
-    const nextTasks = [...createdTasks, ...normalizedTasks];
-    const calibration = createPressureCalibration(referencePressure, nextTasks, 0, new Date().toISOString());
-    setTasks(nextTasks);
-    setPressureCalibration(calibration);
-    unlockAchievement('first-manageable-pressure');
-    recordPressureSnapshot('recalibration', nextTasks, `用户将主观压力重新校准为 ${calibration.lastSubjectivePressure}，系统已更新压力映射系数。`, calibration);
-    savePressure({ baselinePressure: calibration.lastSubjectivePressure, calibration });
-    setOnboardingComplete(true);
+  function completeOnboarding(importedTasks: TaskInput[], referencePressure: number, _calibration: PressureCalibrationSnapshot): { ok: boolean; error?: string } {
+    console.info('[VD_ONBOARDING] submit reached app pipeline');
+
+    try {
+      const createdTasks = importedTasks.map((task) => createTask(task));
+      const validCreatedTasks = createdTasks.filter((task) => task.lifecycleStatus === 'active' && task.progress < 100 && task.title.trim());
+      if (validCreatedTasks.length === 0) throw new Error('请至少保留一个未完成的有效任务后再进入 VD。');
+
+      const nextTasks = [...createdTasks, ...normalizedTasks];
+      const totalTaskPressure = calculateTaskLoad(nextTasks);
+      console.info('[VD_ONBOARDING] totalTaskPressure', totalTaskPressure);
+      if (totalTaskPressure <= 0) throw new Error('当前任务压力为 0，无法完成校准。请检查任务重要性、截止时间或进度。');
+
+      const calibration = createPressureCalibration(referencePressure, nextTasks, 0, new Date().toISOString());
+      if (!Number.isFinite(calibration.pressureCoefficient) || calibration.pressureCoefficient < 0) throw new Error('压力校准失败，请重新选择主观压力。');
+
+      const realtimePressure = calculatePressureIndex(nextTasks, calibration, legacyReferencePressure).rawPressure;
+      if (!Number.isFinite(realtimePressure)) throw new Error('实时压力计算失败，请检查任务数据。');
+
+      console.info('[VD_ONBOARDING] pressureCoefficient', calibration.pressureCoefficient);
+      console.info('[VD_ONBOARDING] realtimePressure', realtimePressure);
+
+      try {
+        saveTasks(nextTasks);
+        console.info('[VD_ONBOARDING] task persistence success', { taskCount: nextTasks.length });
+      } catch (error) {
+        console.error('[VD_ONBOARDING] task persistence failure', error);
+        throw new Error('任务保存失败，请检查浏览器存储权限后重试。');
+      }
+
+      try {
+        savePressure({ baselinePressure: calibration.lastSubjectivePressure, calibration });
+        console.info('[VD_ONBOARDING] user state persistence success', {
+          subjectivePressure: calibration.lastSubjectivePressure,
+          pressureCoefficient: calibration.pressureCoefficient,
+          realtimePressure,
+        });
+      } catch (error) {
+        console.error('[VD_ONBOARDING] user state persistence failure', error);
+        throw new Error('压力校准保存失败，请检查浏览器存储权限后重试。');
+      }
+
+      try {
+        saveValue(storageKeys.onboardingComplete, true);
+        console.info('[VD_ONBOARDING] onboarding completion flag update', true);
+      } catch (error) {
+        console.error('[VD_ONBOARDING] onboarding completion flag update failure', error);
+        throw new Error('引导完成状态保存失败，请检查浏览器存储权限后重试。');
+      }
+
+      const persistedTasks = loadValue<Task[]>(storageKeys.tasks, []);
+      const persistedCalibration = loadValue<PressureCalibrationSnapshot | null>(storageKeys.pressureCalibration, null);
+      const persistedOnboardingComplete = loadValue<boolean>(storageKeys.onboardingComplete, false);
+      const persistedRealtimePressure = calculatePressureIndex(persistedTasks.map((task) => normalizeStoredTask(task)), persistedCalibration, legacyReferencePressure).rawPressure;
+      const persistedStateIsValid = persistedTasks.length >= createdTasks.length
+        && persistedOnboardingComplete === true
+        && Boolean(persistedCalibration)
+        && Number.isFinite(persistedCalibration?.pressureCoefficient)
+        && Number.isFinite(persistedRealtimePressure);
+
+      if (!persistedStateIsValid) throw new Error('保存校验失败：任务或压力校准未正确写入。');
+      console.info('[VD_ONBOARDING] persisted state verified', {
+        taskCount: persistedTasks.length,
+        onboardingComplete: persistedOnboardingComplete,
+        pressureCoefficient: persistedCalibration?.pressureCoefficient,
+        realtimePressure: persistedRealtimePressure,
+      });
+
+      setTasks(nextTasks);
+      setPressureCalibration(calibration);
+      unlockAchievement('first-manageable-pressure');
+      recordPressureSnapshot('recalibration', nextTasks, `用户将主观压力重新校准为 ${calibration.lastSubjectivePressure}，系统已更新压力映射系数。`, calibration);
+      console.info('[VD_ONBOARDING] redirect started');
+      setOnboardingComplete(true);
+      return { ok: true };
+    } catch (error) {
+      try {
+        saveValue(storageKeys.onboardingComplete, false);
+      } catch {
+        // The original error below is more actionable for the user; this rollback is best-effort.
+      }
+      console.error('[VD_ONBOARDING] onboarding pipeline failed', error);
+      return { ok: false, error: error instanceof Error ? error.message : '进入 VD 失败，请稍后重试。' };
+    }
   }
 
   function closeForm() {

--- a/src/components/OnboardingFlow.tsx
+++ b/src/components/OnboardingFlow.tsx
@@ -1,10 +1,15 @@
-import { FormEvent, useMemo, useState } from 'react';
+import { FormEvent, useState } from 'react';
 import type { ActivityType, Importance, LifecycleStatus, PressureCalibrationSnapshot, TaskInput } from '../types/task';
 import { toDatetimeLocalValue } from '../utils/date';
 import { clampImportance, clampPressure, clampProgress, createPressureCalibration, getActivityTypeLabel, getUrgencyWeight } from '../utils/taskScoring';
 
+interface OnboardingCompleteResult {
+  ok: boolean;
+  error?: string;
+}
+
 interface OnboardingFlowProps {
-  onComplete: (tasks: TaskInput[], referencePressure: number, calibration: PressureCalibrationSnapshot) => void;
+  onComplete: (tasks: TaskInput[], referencePressure: number, calibration: PressureCalibrationSnapshot) => OnboardingCompleteResult | Promise<OnboardingCompleteResult>;
 }
 
 const activityTypes: ActivityType[] = ['task', 'schedule', 'study', 'fitness', 'social', 'recovery', 'entertainment', 'other'];
@@ -24,7 +29,8 @@ function createDraftTask(title: string): TaskInput {
 function calculateInitialTaskLoad(tasks: TaskInput[]): number {
   return tasks.reduce((sum, task) => {
     if (task.lifecycleStatus !== 'active') return sum;
-    return sum + getUrgencyWeight(task.deadline) * task.importance;
+    const progressNormalized = clampProgress(task.progress) / 100;
+    return sum + getUrgencyWeight(task.deadline) * clampImportance(task.importance) * (1 - progressNormalized);
   }, 0);
 }
 
@@ -34,8 +40,9 @@ export function OnboardingFlow({ onComplete }: OnboardingFlowProps) {
   const [roughTitles, setRoughTitles] = useState<string[]>([]);
   const [referencePressure, setReferencePressure] = useState(35);
   const [draftTasks, setDraftTasks] = useState<TaskInput[]>([]);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState('');
   const canContinueDump = roughTitles.length > 0;
-  const initialTaskLoad = useMemo(() => calculateInitialTaskLoad(draftTasks), [draftTasks]);
 
   function addRoughTitle(event?: FormEvent<HTMLFormElement>) {
     event?.preventDefault();
@@ -55,7 +62,9 @@ export function OnboardingFlow({ onComplete }: OnboardingFlowProps) {
     setDraftTasks((current) => current.map((task, taskIndex) => (taskIndex === index ? { ...task, ...values } : task)));
   }
 
-  function completeOnboarding() {
+  async function completeOnboarding() {
+    if (isSubmitting) return;
+    setSubmitError('');
     const refinedTasks = draftTasks.map((task) => ({
       ...task,
       title: task.title.trim() || '未命名项目',
@@ -65,9 +74,46 @@ export function OnboardingFlow({ onComplete }: OnboardingFlowProps) {
       lifecycleStatus: 'active' as LifecycleStatus,
     }));
 
-    // Future versions can compare this initial load with later user behavior to learn
-    // personalized urgency/importance weighting. No machine learning is implemented here.
-    onComplete(refinedTasks, referencePressure, createPressureCalibration(referencePressure, initialTaskLoad, refinedTasks.length));
+    const validTasks = refinedTasks.filter((task) => task.title.trim() && task.lifecycleStatus === 'active' && task.progress < 100);
+    const safeReferencePressure = clampPressure(referencePressure);
+    const totalTaskPressure = calculateInitialTaskLoad(refinedTasks);
+
+    console.info('[VD_ONBOARDING] submit started');
+    console.info('[VD_ONBOARDING] tasks before save', refinedTasks);
+    console.info('[VD_ONBOARDING] subjectivePressure before calibration', safeReferencePressure);
+    console.info('[VD_ONBOARDING] totalTaskPressure', totalTaskPressure);
+
+    if (validTasks.length === 0) {
+      setSubmitError('请至少保留一个未完成的有效任务后再进入 VD。');
+      return;
+    }
+
+    if (!Number.isFinite(safeReferencePressure)) {
+      setSubmitError('主观压力数值无效，请重新选择。');
+      return;
+    }
+
+    if (totalTaskPressure <= 0) {
+      setSubmitError('当前任务压力为 0，无法完成校准。请检查任务重要性、截止时间或进度。');
+      return;
+    }
+
+    const calibration = createPressureCalibration(safeReferencePressure, totalTaskPressure, refinedTasks.length);
+    console.info('[VD_ONBOARDING] pressureCoefficient', calibration.pressureCoefficient);
+    console.info('[VD_ONBOARDING] realtimePressure', totalTaskPressure * calibration.pressureCoefficient);
+
+    try {
+      setIsSubmitting(true);
+      const result = await onComplete(refinedTasks, safeReferencePressure, calibration);
+      if (!result.ok) {
+        setSubmitError(result.error || '保存失败，请稍后重试。');
+      }
+    } catch (error) {
+      console.error('[VD_ONBOARDING] onboarding submit failed', error);
+      setSubmitError(error instanceof Error ? error.message : '保存失败，请稍后重试。');
+    } finally {
+      setIsSubmitting(false);
+    }
   }
 
   return (
@@ -140,7 +186,10 @@ export function OnboardingFlow({ onComplete }: OnboardingFlowProps) {
             </div>
             <div className="mt-8 flex justify-between gap-3">
               <button type="button" onClick={() => setStep(2)} className="rounded-full px-5 py-3 text-sm font-semibold text-slate-500 hover:bg-slate-100">返回</button>
-              <button type="button" onClick={completeOnboarding} className="rounded-full bg-white/85 px-6 py-3 text-sm font-semibold text-slate-700 shadow-sm ring-1 ring-slate-200 hover:bg-slate-50">进入 VD</button>
+              <div className="flex flex-col items-end gap-2">
+                {submitError ? <p className="max-w-md rounded-2xl bg-rose-50 px-4 py-2 text-sm text-rose-700 ring-1 ring-rose-100">{submitError}</p> : null}
+                <button type="button" onClick={completeOnboarding} disabled={isSubmitting} className="rounded-full bg-white/85 px-6 py-3 text-sm font-semibold text-slate-700 shadow-sm ring-1 ring-slate-200 hover:bg-slate-50 disabled:cursor-not-allowed disabled:text-slate-300">{isSubmitting ? '保存中…' : '进入 VD'}</button>
+              </div>
             </div>
           </div>
         ) : null}

--- a/src/lib/pressureEngine.ts
+++ b/src/lib/pressureEngine.ts
@@ -66,13 +66,20 @@ export function isUnfinishedPressureTask(task: Task): boolean {
   return task.lifecycleStatus === 'active' && task.progress < 100;
 }
 
+function normalizeProgressPressure(progress?: number): number {
+  if (typeof progress !== 'number' || Number.isNaN(progress)) return 0;
+  return Math.min(100, Math.max(0, progress));
+}
+
 export function calculateTaskPressure(task: Task, now: string | number | Date = new Date(), weights: PressureModelWeights = defaultPressureModelWeights): number {
   const urgency = calculateUrgency(task.deadline, now);
+  const progressNormalized = normalizeProgressPressure(task.progress) / 100;
+  const remainingWorkMultiplier = 1 - progressNormalized;
   const importanceTerm = weights.importanceWeight * task.importance;
   const urgencyTerm = weights.urgencyWeight * urgency;
-  const interactionTerm = weights.interactionWeight * task.importance * urgency;
+  const interactionTerm = weights.interactionWeight * task.importance * urgency * remainingWorkMultiplier;
 
-  // Default VD v1 model: taskPressure = importance × urgency.
+  // Default VD v1 model: taskPressure = importance × urgency × remaining work.
   // The additive terms are intentionally present for future personalization:
   // α × importance + β × urgency + γ × interactionTerm.
   return roundToHundredth(importanceTerm + urgencyTerm + interactionTerm);
@@ -116,12 +123,11 @@ export function calibratePressure(tasks: Task[], subjectivePressure: number, now
     pressureRatio: roundToFourDecimals(pressureCoefficient),
     taskCount: tasks.filter(isUnfinishedPressureTask).length,
     capturedAt: calibratedAt,
-    note: 'subjective pressure calibrates the current raw task pressure: realtimePressure = currentRawPressure × pressureCoefficient - recoveryRelease.',
+    note: 'subjective pressure calibrates the current raw task pressure: realtimePressure = currentRawPressure × pressureCoefficient.',
   };
 }
 
-export function calculateRealtimePressure(tasks: Task[], pressureCoefficient: number, recoveryRelease = 0, now: string | number | Date = new Date(), weights: PressureModelWeights = defaultPressureModelWeights): number {
-  const safeCoefficient = Number.isFinite(pressureCoefficient) && pressureCoefficient > 0 ? pressureCoefficient : DEFAULT_PRESSURE_COEFFICIENT;
-  const safeRecoveryRelease = Number.isFinite(recoveryRelease) ? Math.max(0, recoveryRelease) : 0;
-  return Math.max(0, calculateRawPressure(tasks, now, weights) * safeCoefficient - safeRecoveryRelease);
+export function calculateRealtimePressure(tasks: Task[], pressureCoefficient: number, _recoveryRelease = 0, now: string | number | Date = new Date(), weights: PressureModelWeights = defaultPressureModelWeights): number {
+  const safeCoefficient = Number.isFinite(pressureCoefficient) && pressureCoefficient >= 0 ? pressureCoefficient : DEFAULT_PRESSURE_COEFFICIENT;
+  return Math.max(0, calculateRawPressure(tasks, now, weights) * safeCoefficient);
 }

--- a/src/utils/taskScoring.ts
+++ b/src/utils/taskScoring.ts
@@ -220,7 +220,7 @@ export function createPressureCalibration(referencePressure: number, sourceTasks
     pressureRatio: roundToFourDecimals(pressureCoefficient),
     taskCount,
     capturedAt,
-    note: 'subjective pressure calibrates the current raw task pressure: realtimePressure = currentRawPressure × pressureCoefficient - recoveryRelease.',
+    note: 'subjective pressure calibrates the current raw task pressure: realtimePressure = currentRawPressure × pressureCoefficient.',
   };
 }
 
@@ -229,9 +229,9 @@ export function normalizePressureCalibration(calibration?: Partial<PressureCalib
   const lastSubjectivePressure = clampPressure(calibration?.lastSubjectivePressure ?? calibration?.referencePressure ?? legacyCalibration?.baselinePressure ?? legacyReferencePressure);
   const storedRawPressure = calibration?.rawPressureAtCalibration ?? calibration?.referenceTaskLoad ?? legacyCalibration?.initialTotalTaskLoad;
   const rawPressureAtCalibration = typeof storedRawPressure === 'number' && Number.isFinite(storedRawPressure) ? Math.max(0, storedRawPressure) : Math.max(MIN_REFERENCE_TASK_LOAD, lastSubjectivePressure / DEFAULT_PRESSURE_RATIO);
-  const pressureCoefficient = typeof calibration?.pressureCoefficient === 'number' && Number.isFinite(calibration.pressureCoefficient) && calibration.pressureCoefficient > 0
+  const pressureCoefficient = typeof calibration?.pressureCoefficient === 'number' && Number.isFinite(calibration.pressureCoefficient) && calibration.pressureCoefficient >= 0
     ? calibration.pressureCoefficient
-    : typeof calibration?.pressureRatio === 'number' && Number.isFinite(calibration.pressureRatio) && calibration.pressureRatio > 0
+    : typeof calibration?.pressureRatio === 'number' && Number.isFinite(calibration.pressureRatio) && calibration.pressureRatio >= 0
       ? calibration.pressureRatio
       : lastSubjectivePressure / Math.max(MIN_REFERENCE_TASK_LOAD, rawPressureAtCalibration);
   const calibratedAt = calibration?.calibratedAt || calibration?.capturedAt || new Date().toISOString();


### PR DESCRIPTION
### Motivation
- Onboarding could mark completion and navigate into VD before tasks and pressure calibration were reliably persisted, causing lost tasks and no effective calibration. 
- Realtime pressure used a model that ignored task progress and could produce stale or invalid values after onboarding. 
- The submit flow had no clear failure handling or verification, allowing silent failures and race conditions. 

### Description
- Harden onboarding submit flow: `OnboardingFlow` now validates tasks and subjective pressure, computes total task pressure including remaining work, blocks duplicate submits, shows a concise error UI, and awaits the app-level persistence result before returning control. (`src/components/OnboardingFlow.tsx`).
- Move persistence+verification into the app pipeline: `App.completeOnboarding` now calculates `totalTaskPressure`, creates calibration, persistently saves tasks and pressure (using `saveTasks`/`savePressure`), writes the onboarding flag only after successful writes, verifies persisted state from storage, and returns a clear success/error result; failures roll back the onboarding flag and do not redirect. (`src/App.tsx`).
- Update pressure model so task pressure accounts for remaining work: task pressure now multiplies importance × urgency × (1 - progressNormalized), with safe progress normalization and coefficient handling; realtime pressure is computed as currentRawPressure × pressureCoefficient. (`src/lib/pressureEngine.ts`, `src/utils/taskScoring.ts`).
- Ensure realtime pressure updates over time and on task mutations by adding a minute clock to the derived `pressure` calculation so urgency changes propagate while the app is open. (`src/App.tsx`).
- Add scoped debug logs using the `[VD_ONBOARDING]` prefix for submit start, pre-save task/calibration values, persistence successes/failures, persisted-state verification, hydration restore, and redirect steps. (`src/components/OnboardingFlow.tsx`, `src/App.tsx`).

### Testing
- Ran static/build verification with `git diff --check` which produced no whitespace errors and passed. (success)
- Ran the full TypeScript + production build via `npm run build` (which runs `tsc -b` and `vite build`) and the build completed successfully. (success)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a068824fc98832c9a118bc142a10066)