### PR TITLE
Add Supabase auth and cloud sync MVP

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import { type ReactElement, useEffect, useMemo, useRef, useState } from 'react';
 import { AchievementToast } from './components/AchievementToast';
+import { AuthPanel } from './components/AuthPanel';
 import { HomePage } from './components/HomePage';
 import { LifeMapPage } from './components/LifeMapPage';
 import { LifeOSNav } from './components/LifeOSNav';
@@ -10,6 +11,7 @@ import { TaskForm } from './components/TaskForm';
 import { SocialPage } from './components/SocialPage';
 import { TaskPage } from './components/TaskPage';
 import { useLocalStorage } from './hooks/useLocalStorage';
+import { useSupabaseAuth } from './hooks/useSupabaseAuth';
 import type { Achievement, AIArtifact, AIArtifactInput, ActivityType, Goal, GoalInput, LifecycleStatus, LifeOSModule, PressureBreakdown, PressureCalibrationSnapshot, PressureHistoryEventType, PressureHistoryRecord, Task, TaskInput, UserProfile } from './types/task';
 import {
   achievementCatalog,
@@ -28,6 +30,7 @@ import {
   normalizeProgressMode,
 } from './utils/taskScoring';
 import { appendPressureHistoryRecord, createPressureHistoryRecord, normalizePressureHistory } from './utils/pressureHistory';
+import { loadCloudData, saveCloudGoals, saveCloudPressureHistory, saveCloudProfile, saveCloudTasks } from './lib/cloudSync';
 import { hasValue, loadValue, savePressure, saveTasks, saveValue, storageKeys } from './storage';
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
@@ -317,6 +320,14 @@ function createTask(input: TaskInput): Task {
   };
 }
 
+
+function mergeById<T extends { id: string }>(localItems: T[], cloudItems: T[]): T[] {
+  const merged = new Map<string, T>();
+  localItems.forEach((item) => merged.set(item.id, item));
+  cloudItems.forEach((item) => merged.set(item.id, item));
+  return Array.from(merged.values());
+}
+
 function createAchievement(id: string): Achievement | undefined {
   const achievement = achievementCatalog.find((item) => item.id === id);
   if (!achievement) return undefined;
@@ -331,6 +342,13 @@ function createAchievement(id: string): Achievement | undefined {
 }
 
 function App() {
+  const { session, isLoading: isAuthLoading, error: authError, isConfigured: isSupabaseConfigured, signIn, signUp, signOut } = useSupabaseAuth();
+  const [hasChosenGuestMode, setHasChosenGuestMode] = useState(false);
+  const [cloudStatus, setCloudStatus] = useState<string | undefined>();
+  const [cloudError, setCloudError] = useState<string | undefined>();
+  const [isCloudLoading, setIsCloudLoading] = useState(false);
+  const [isCloudReady, setIsCloudReady] = useState(false);
+  const isApplyingCloudData = useRef(false);
   const [tasks, setTasks] = useLocalStorage<Task[]>(storageKeys.tasks, []);
   const [goals, setGoals] = useLocalStorage<Goal[]>(storageKeys.goals, []);
   const [achievements, setAchievements] = useLocalStorage<Achievement[]>(storageKeys.achievements, []);
@@ -369,6 +387,84 @@ function App() {
     const previewCalibration = createPressureCalibration(recalibrationPressure, normalizedTasks, 0, new Date().toISOString());
     return calculatePressureIndex(normalizedTasks, previewCalibration, legacyReferencePressure);
   }, [legacyReferencePressure, normalizedTasks, recalibrationPressure]);
+
+  const syncModeLabel = session ? `云同步：${session.user.email || session.user.id}` : '本地模式';
+
+  useEffect(() => {
+    if (!session) {
+      setIsCloudReady(false);
+      setCloudStatus(undefined);
+      setCloudError(undefined);
+      return;
+    }
+
+    let isMounted = true;
+    setIsCloudLoading(true);
+    setCloudError(undefined);
+    setCloudStatus('正在从 Supabase 读取云端数据…');
+    loadCloudData(session)
+      .then(async (cloudData) => {
+        if (!isMounted) return;
+        isApplyingCloudData.current = true;
+        const mergedTasks = mergeById(normalizedTasks, cloudData.tasks);
+        const mergedGoals = mergeById(normalizedGoals, cloudData.goals);
+        const mergedPressureHistory = mergeById(normalizedPressureHistory, cloudData.pressureHistory);
+        setTasks(mergedTasks);
+        setGoals(mergedGoals);
+        setPressureHistory(mergedPressureHistory);
+        if (cloudData.profile) setProfile(cloudData.profile);
+        if (cloudData.pressureCalibration) setPressureCalibration(cloudData.pressureCalibration);
+        if (cloudData.onboardingComplete !== null) setOnboardingComplete(cloudData.onboardingComplete);
+        setIsCloudReady(true);
+        await Promise.all([
+          saveCloudTasks(mergedTasks, session),
+          saveCloudGoals(mergedGoals, session),
+          saveCloudPressureHistory(mergedPressureHistory, session),
+          saveCloudProfile({
+            profile: cloudData.profile ?? normalizedProfile,
+            pressureCalibration: cloudData.pressureCalibration ?? normalizedPressureCalibration,
+            onboardingComplete: cloudData.onboardingComplete ?? onboardingComplete,
+          }, session),
+        ]);
+        setCloudStatus('云端数据已读取，本机和导入数据已合并上传。');
+        window.setTimeout(() => {
+          isApplyingCloudData.current = false;
+        }, 0);
+      })
+      .catch((error) => {
+        if (!isMounted) return;
+        setCloudError(error instanceof Error ? error.message : '云同步读取失败。');
+      })
+      .finally(() => {
+        if (isMounted) setIsCloudLoading(false);
+      });
+
+    return () => {
+      isMounted = false;
+    };
+  }, [session?.access_token, session?.user.id]);
+
+  useEffect(() => {
+    if (!session || !isCloudReady || isApplyingCloudData.current) return;
+    saveCloudTasks(normalizedTasks, session).then(() => setCloudStatus('任务已同步到 Supabase。')).catch((error) => setCloudError(error instanceof Error ? error.message : '任务云同步失败。'));
+  }, [isCloudReady, normalizedTasks, session]);
+
+  useEffect(() => {
+    if (!session || !isCloudReady || isApplyingCloudData.current) return;
+    saveCloudGoals(normalizedGoals, session).then(() => setCloudStatus('目标已同步到 Supabase。')).catch((error) => setCloudError(error instanceof Error ? error.message : '目标云同步失败。'));
+  }, [isCloudReady, normalizedGoals, session]);
+
+  useEffect(() => {
+    if (!session || !isCloudReady || isApplyingCloudData.current) return;
+    saveCloudPressureHistory(normalizedPressureHistory, session).then(() => setCloudStatus('压力历史已同步到 Supabase。')).catch((error) => setCloudError(error instanceof Error ? error.message : '压力历史云同步失败。'));
+  }, [isCloudReady, normalizedPressureHistory, session]);
+
+  useEffect(() => {
+    if (!session || !isCloudReady || isApplyingCloudData.current) return;
+    saveCloudProfile({ profile: normalizedProfile, pressureCalibration: normalizedPressureCalibration, onboardingComplete }, session)
+      .then(() => setCloudStatus('个人设置已同步到 Supabase。'))
+      .catch((error) => setCloudError(error instanceof Error ? error.message : '个人设置云同步失败。'));
+  }, [isCloudReady, normalizedPressureCalibration, normalizedProfile, onboardingComplete, session]);
 
   useEffect(() => {
     const intervalId = window.setInterval(() => setPressureClock(Date.now()), 60 * 1000);
@@ -815,6 +911,10 @@ function App() {
     me: <ProfilePage profile={normalizedProfile} onProfileChange={setProfile} />,
   };
 
+  if (!session && !hasChosenGuestMode) {
+    return <AuthPanel isConfigured={isSupabaseConfigured} isLoading={isAuthLoading} error={authError} onSignIn={signIn} onSignUp={signUp} onContinueAsGuest={() => setHasChosenGuestMode(true)} />;
+  }
+
   return (
     <main className="min-h-screen bg-[radial-gradient(circle_at_top_left,#dbeafe,transparent_32%),radial-gradient(circle_at_top_right,#f8fafc,transparent_30%),linear-gradient(180deg,#f8fafc,#eef2f7)] px-4 py-8 text-slate-900 md:px-8">
       {!onboardingComplete ? <OnboardingFlow onComplete={completeOnboarding} /> : null}
@@ -863,6 +963,17 @@ function App() {
       ) : null}
 
       <div className="mx-auto max-w-6xl space-y-5 md:space-y-6">
+        <section className="flex flex-wrap items-center justify-between gap-3 rounded-[2rem] border border-white/70 bg-white/75 px-5 py-3 text-sm shadow-lg shadow-slate-200/50 backdrop-blur">
+          <div>
+            <p className="font-semibold text-slate-700">{syncModeLabel}</p>
+            <p className={`mt-1 text-xs ${cloudError ? 'text-rose-600' : 'text-slate-500'}`}>{cloudError || cloudStatus || (session ? '云同步准备中…' : '未登录时仅使用 localStorage，不会上传数据。')}</p>
+          </div>
+          {session ? (
+            <button type="button" onClick={signOut} disabled={isCloudLoading} className="rounded-full bg-white/85 px-4 py-2 text-xs font-semibold text-slate-700 shadow-sm ring-1 ring-slate-200 hover:bg-slate-50 disabled:cursor-not-allowed disabled:text-slate-300">退出登录</button>
+          ) : (
+            <button type="button" onClick={() => setHasChosenGuestMode(false)} className="rounded-full bg-slate-950 px-4 py-2 text-xs font-semibold text-white shadow-sm">登录同步</button>
+          )}
+        </section>
         <LifeOSNav activeModule={activeModule} onModuleChange={setActiveModule} />
         {moduleContent[activeModule]}
       </div>

--- a/src/components/AuthPanel.tsx
+++ b/src/components/AuthPanel.tsx
@@ -1,0 +1,74 @@
+import { useState, type FormEvent } from 'react';
+
+interface AuthPanelProps {
+  isConfigured: boolean;
+  isLoading: boolean;
+  error?: string;
+  onSignIn: (email: string, password: string) => Promise<unknown>;
+  onSignUp: (email: string, password: string) => Promise<unknown>;
+  onContinueAsGuest: () => void;
+}
+
+export function AuthPanel({ isConfigured, isLoading, error, onSignIn, onSignUp, onContinueAsGuest }: AuthPanelProps) {
+  const [mode, setMode] = useState<'signin' | 'signup'>('signin');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [status, setStatus] = useState<string | undefined>();
+  const [formError, setFormError] = useState<string | undefined>();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setFormError(undefined);
+    setStatus(undefined);
+    if (!email.trim() || password.length < 6) {
+      setFormError('请输入有效邮箱，并使用至少 6 位密码。');
+      return;
+    }
+    setIsSubmitting(true);
+    try {
+      const session = mode === 'signin' ? await onSignIn(email.trim(), password) : await onSignUp(email.trim(), password);
+      if (!session && mode === 'signup') setStatus('注册成功。请检查邮箱完成验证，然后回到这里登录。');
+    } catch (submitError) {
+      setFormError(submitError instanceof Error ? submitError.message : '认证失败，请稍后重试。');
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <main className="min-h-screen bg-[radial-gradient(circle_at_top_left,#dbeafe,transparent_32%),linear-gradient(180deg,#f8fafc,#eef2f7)] px-4 py-10 text-slate-900">
+      <section className="mx-auto max-w-xl rounded-[2rem] border border-white/80 bg-white/85 p-7 shadow-2xl shadow-slate-300/60 backdrop-blur">
+        <p className="text-xs font-semibold uppercase tracking-[0.28em] text-slate-400">Visual Deadline Cloud</p>
+        <h1 className="mt-3 text-3xl font-semibold tracking-tight text-slate-950">登录以启用云同步</h1>
+        <p className="mt-3 text-sm leading-6 text-slate-500">使用 Supabase 邮箱密码登录后，任务、目标与压力历史会按你的用户 ID 隔离同步。也可以继续使用本机 localStorage。</p>
+
+        {!isConfigured ? (
+          <p className="mt-5 rounded-2xl bg-amber-50 px-4 py-3 text-sm text-amber-700 ring-1 ring-amber-100">当前缺少 VITE_SUPABASE_URL 或 VITE_SUPABASE_ANON_KEY，云同步不可用。</p>
+        ) : null}
+        {isLoading ? <p className="mt-5 rounded-2xl bg-sky-50 px-4 py-3 text-sm text-sky-700 ring-1 ring-sky-100">正在恢复登录状态…</p> : null}
+        {error || formError ? <p className="mt-5 rounded-2xl bg-rose-50 px-4 py-3 text-sm text-rose-600 ring-1 ring-rose-100">{formError || error}</p> : null}
+        {status ? <p className="mt-5 rounded-2xl bg-emerald-50 px-4 py-3 text-sm text-emerald-700 ring-1 ring-emerald-100">{status}</p> : null}
+
+        <div className="mt-6 grid grid-cols-2 gap-2 rounded-full bg-slate-100 p-1 text-sm font-semibold text-slate-500">
+          <button type="button" onClick={() => setMode('signin')} className={`rounded-full px-4 py-2 ${mode === 'signin' ? 'bg-white text-slate-900 shadow-sm' : ''}`}>登录</button>
+          <button type="button" onClick={() => setMode('signup')} className={`rounded-full px-4 py-2 ${mode === 'signup' ? 'bg-white text-slate-900 shadow-sm' : ''}`}>注册</button>
+        </div>
+
+        <form onSubmit={handleSubmit} className="mt-5 space-y-4">
+          <label className="block text-sm font-semibold text-slate-600">邮箱
+            <input type="email" value={email} onChange={(event) => setEmail(event.target.value)} className="mt-2 w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-slate-900 outline-none focus:border-sky-300" autoComplete="email" />
+          </label>
+          <label className="block text-sm font-semibold text-slate-600">密码
+            <input type="password" value={password} onChange={(event) => setPassword(event.target.value)} className="mt-2 w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-slate-900 outline-none focus:border-sky-300" autoComplete={mode === 'signin' ? 'current-password' : 'new-password'} />
+          </label>
+          <button type="submit" disabled={!isConfigured || isLoading || isSubmitting} className="w-full rounded-full bg-slate-950 px-5 py-3 text-sm font-semibold text-white shadow-lg shadow-slate-300 disabled:cursor-not-allowed disabled:bg-slate-300">
+            {isSubmitting ? '处理中…' : mode === 'signin' ? '登录并同步' : '注册账号'}
+          </button>
+        </form>
+
+        <button type="button" onClick={onContinueAsGuest} className="mt-4 w-full rounded-full bg-white/85 px-5 py-3 text-sm font-semibold text-slate-700 ring-1 ring-slate-200 hover:bg-slate-50">继续使用本地模式</button>
+      </section>
+    </main>
+  );
+}

--- a/src/hooks/useSupabaseAuth.ts
+++ b/src/hooks/useSupabaseAuth.ts
@@ -1,0 +1,50 @@
+import { useCallback, useEffect, useState } from 'react';
+import { supabase, type SupabaseSession } from '../lib/supabaseClient';
+
+export function useSupabaseAuth() {
+  const [session, setSession] = useState<SupabaseSession | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | undefined>();
+
+  useEffect(() => {
+    let isMounted = true;
+    supabase.auth.getSession()
+      .then((currentSession) => {
+        if (isMounted) setSession(currentSession);
+      })
+      .catch((authError) => {
+        if (isMounted) setError(authError instanceof Error ? authError.message : '读取登录状态失败。');
+      })
+      .finally(() => {
+        if (isMounted) setIsLoading(false);
+      });
+
+    const subscription = supabase.auth.onAuthStateChange((nextSession) => setSession(nextSession));
+    return () => {
+      isMounted = false;
+      subscription.data.subscription.unsubscribe();
+    };
+  }, []);
+
+  const signUp = useCallback(async (email: string, password: string) => {
+    setError(undefined);
+    const nextSession = await supabase.auth.signUp(email, password);
+    if (nextSession) setSession(nextSession);
+    return nextSession;
+  }, []);
+
+  const signIn = useCallback(async (email: string, password: string) => {
+    setError(undefined);
+    const nextSession = await supabase.auth.signInWithPassword(email, password);
+    setSession(nextSession);
+    return nextSession;
+  }, []);
+
+  const signOut = useCallback(async () => {
+    setError(undefined);
+    await supabase.auth.signOut();
+    setSession(null);
+  }, []);
+
+  return { session, isLoading, error, isConfigured: supabase.isConfigured, signUp, signIn, signOut };
+}

--- a/src/lib/cloudSync.ts
+++ b/src/lib/cloudSync.ts
@@ -1,0 +1,91 @@
+import type { Goal, PressureCalibrationSnapshot, PressureHistoryRecord, Task, UserProfile } from '../types/task';
+import { supabase, type SupabaseSession } from './supabaseClient';
+
+interface JsonRow<T> {
+  id: string;
+  data: T;
+  updated_at?: string;
+}
+
+interface ProfileRow {
+  user_id: string;
+  profile: UserProfile | null;
+  pressure_calibration: PressureCalibrationSnapshot | null;
+  onboarding_complete: boolean;
+  updated_at?: string;
+}
+
+export interface CloudData {
+  tasks: Task[];
+  goals: Goal[];
+  pressureHistory: PressureHistoryRecord[];
+  profile: UserProfile | null;
+  pressureCalibration: PressureCalibrationSnapshot | null;
+  onboardingComplete: boolean | null;
+}
+
+const encode = (value: string) => encodeURIComponent(value).replace(/'/g, '%27');
+
+function rowFromEntity<T extends { id: string }>(entity: T, userId: string) {
+  return { id: entity.id, user_id: userId, data: entity, updated_at: new Date().toISOString() };
+}
+
+async function loadJsonRows<T>(table: 'tasks' | 'goals' | 'pressure_logs', session: SupabaseSession): Promise<T[]> {
+  const rows = await supabase.rest<JsonRow<T>[]>(`${table}?select=id,data,updated_at&user_id=eq.${encode(session.user.id)}`, { method: 'GET' }, session);
+  return rows.map((row) => row.data).filter(Boolean);
+}
+
+async function replaceJsonRows<T extends { id: string }>(table: 'tasks' | 'goals' | 'pressure_logs', values: T[], session: SupabaseSession): Promise<void> {
+  await supabase.rest(`${table}?user_id=eq.${encode(session.user.id)}`, { method: 'DELETE' }, session);
+  if (values.length === 0) return;
+  await supabase.rest(table, {
+    method: 'POST',
+    headers: { Prefer: 'resolution=merge-duplicates' },
+    body: JSON.stringify(values.map((value) => rowFromEntity(value, session.user.id))),
+  }, session);
+}
+
+export async function loadCloudData(session: SupabaseSession): Promise<CloudData> {
+  const [tasks, goals, pressureHistory, profiles] = await Promise.all([
+    loadJsonRows<Task>('tasks', session),
+    loadJsonRows<Goal>('goals', session),
+    loadJsonRows<PressureHistoryRecord>('pressure_logs', session),
+    supabase.rest<ProfileRow[]>(`profiles?select=user_id,profile,pressure_calibration,onboarding_complete&user_id=eq.${encode(session.user.id)}&limit=1`, { method: 'GET' }, session),
+  ]);
+  const profile = profiles[0];
+  return {
+    tasks,
+    goals,
+    pressureHistory,
+    profile: profile?.profile ?? null,
+    pressureCalibration: profile?.pressure_calibration ?? null,
+    onboardingComplete: typeof profile?.onboarding_complete === 'boolean' ? profile.onboarding_complete : null,
+  };
+}
+
+export async function saveCloudTasks(tasks: Task[], session: SupabaseSession): Promise<void> {
+  await replaceJsonRows('tasks', tasks, session);
+}
+
+export async function saveCloudGoals(goals: Goal[], session: SupabaseSession): Promise<void> {
+  await replaceJsonRows('goals', goals, session);
+}
+
+export async function saveCloudPressureHistory(records: PressureHistoryRecord[], session: SupabaseSession): Promise<void> {
+  await replaceJsonRows('pressure_logs', records, session);
+}
+
+export async function saveCloudProfile(input: { profile: UserProfile; pressureCalibration: PressureCalibrationSnapshot; onboardingComplete: boolean }, session: SupabaseSession): Promise<void> {
+  await supabase.rest('profiles', {
+    method: 'POST',
+    headers: { Prefer: 'resolution=merge-duplicates' },
+    body: JSON.stringify({
+      user_id: session.user.id,
+      email: session.user.email ?? null,
+      profile: input.profile,
+      pressure_calibration: input.pressureCalibration,
+      onboarding_complete: input.onboardingComplete,
+      updated_at: new Date().toISOString(),
+    }),
+  }, session);
+}

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -1,0 +1,153 @@
+export interface SupabaseUser {
+  id: string;
+  email?: string;
+}
+
+export interface SupabaseSession {
+  access_token: string;
+  refresh_token: string;
+  expires_at?: number;
+  user: SupabaseUser;
+}
+
+type AuthChangeCallback = (session: SupabaseSession | null) => void;
+
+const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL as string | undefined;
+const SUPABASE_ANON_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY as string | undefined;
+const SESSION_STORAGE_KEY = 'vd.supabase.session';
+
+function getRequiredConfig() {
+  if (!SUPABASE_URL || !SUPABASE_ANON_KEY) {
+    throw new Error('缺少 Supabase 环境变量：请配置 VITE_SUPABASE_URL 和 VITE_SUPABASE_ANON_KEY。');
+  }
+  return { url: SUPABASE_URL.replace(/\/$/, ''), anonKey: SUPABASE_ANON_KEY };
+}
+
+function readStoredSession(): SupabaseSession | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const raw = window.localStorage.getItem(SESSION_STORAGE_KEY);
+    return raw ? (JSON.parse(raw) as SupabaseSession) : null;
+  } catch {
+    return null;
+  }
+}
+
+function persistSession(session: SupabaseSession | null): void {
+  if (typeof window === 'undefined') return;
+  if (session) window.localStorage.setItem(SESSION_STORAGE_KEY, JSON.stringify(session));
+  else window.localStorage.removeItem(SESSION_STORAGE_KEY);
+}
+
+function toSession(payload: { access_token: string; refresh_token: string; expires_in?: number; user: SupabaseUser }): SupabaseSession {
+  return {
+    access_token: payload.access_token,
+    refresh_token: payload.refresh_token,
+    expires_at: payload.expires_in ? Math.floor(Date.now() / 1000) + payload.expires_in : undefined,
+    user: payload.user,
+  };
+}
+
+async function parseResponse<T>(response: Response): Promise<T> {
+  const text = await response.text();
+  const body = text ? JSON.parse(text) : null;
+  if (!response.ok) {
+    const message = body?.msg || body?.message || body?.error_description || body?.error || 'Supabase 请求失败。';
+    throw new Error(message);
+  }
+  return body as T;
+}
+
+class VisualDeadlineSupabaseClient {
+  private listeners = new Set<AuthChangeCallback>();
+
+  get isConfigured(): boolean {
+    return Boolean(SUPABASE_URL && SUPABASE_ANON_KEY);
+  }
+
+  auth = {
+    getSession: async (): Promise<SupabaseSession | null> => {
+      const stored = readStoredSession();
+      if (!stored) return null;
+      if (stored.expires_at && stored.expires_at - 60 < Math.floor(Date.now() / 1000)) {
+        return this.auth.refreshSession(stored.refresh_token);
+      }
+      return stored;
+    },
+    signUp: async (email: string, password: string): Promise<SupabaseSession | null> => {
+      const { url, anonKey } = getRequiredConfig();
+      const payload = await parseResponse<{ access_token?: string; refresh_token?: string; expires_in?: number; user: SupabaseUser }>(await fetch(`${url}/auth/v1/signup`, {
+        method: 'POST',
+        headers: { apikey: anonKey, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, password }),
+      }));
+      if (!payload.access_token || !payload.refresh_token) return null;
+      const session = toSession(payload as { access_token: string; refresh_token: string; expires_in?: number; user: SupabaseUser });
+      persistSession(session);
+      this.emit(session);
+      return session;
+    },
+    signInWithPassword: async (email: string, password: string): Promise<SupabaseSession> => {
+      const { url, anonKey } = getRequiredConfig();
+      const payload = await parseResponse<{ access_token: string; refresh_token: string; expires_in?: number; user: SupabaseUser }>(await fetch(`${url}/auth/v1/token?grant_type=password`, {
+        method: 'POST',
+        headers: { apikey: anonKey, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, password }),
+      }));
+      const session = toSession(payload);
+      persistSession(session);
+      this.emit(session);
+      return session;
+    },
+    refreshSession: async (refreshToken: string): Promise<SupabaseSession | null> => {
+      const { url, anonKey } = getRequiredConfig();
+      try {
+        const payload = await parseResponse<{ access_token: string; refresh_token: string; expires_in?: number; user: SupabaseUser }>(await fetch(`${url}/auth/v1/token?grant_type=refresh_token`, {
+          method: 'POST',
+          headers: { apikey: anonKey, 'Content-Type': 'application/json' },
+          body: JSON.stringify({ refresh_token: refreshToken }),
+        }));
+        const session = toSession(payload);
+        persistSession(session);
+        this.emit(session);
+        return session;
+      } catch {
+        persistSession(null);
+        this.emit(null);
+        return null;
+      }
+    },
+    signOut: async (): Promise<void> => {
+      const session = readStoredSession();
+      const config = this.isConfigured ? getRequiredConfig() : null;
+      if (session && config) {
+        await fetch(`${config.url}/auth/v1/logout`, {
+          method: 'POST',
+          headers: { apikey: config.anonKey, Authorization: `Bearer ${session.access_token}` },
+        }).catch(() => undefined);
+      }
+      persistSession(null);
+      this.emit(null);
+    },
+    onAuthStateChange: (callback: AuthChangeCallback) => {
+      this.listeners.add(callback);
+      return { data: { subscription: { unsubscribe: () => this.listeners.delete(callback) } } };
+    },
+  };
+
+  async rest<T>(path: string, init: RequestInit = {}, session?: SupabaseSession | null): Promise<T> {
+    const { url, anonKey } = getRequiredConfig();
+    const activeSession = session ?? (await this.auth.getSession());
+    const headers = new Headers(init.headers);
+    headers.set('apikey', anonKey);
+    headers.set('Content-Type', 'application/json');
+    if (activeSession) headers.set('Authorization', `Bearer ${activeSession.access_token}`);
+    return parseResponse<T>(await fetch(`${url}/rest/v1/${path}`, { ...init, headers }));
+  }
+
+  private emit(session: SupabaseSession | null): void {
+    this.listeners.forEach((listener) => listener(session));
+  }
+}
+
+export const supabase = new VisualDeadlineSupabaseClient();

--- a/supabase-schema.sql
+++ b/supabase-schema.sql
@@ -1,0 +1,65 @@
+-- Visual Deadline Supabase MVP schema
+-- Run this in the Supabase SQL editor for the project used by VITE_SUPABASE_URL.
+
+create table if not exists public.profiles (
+  user_id uuid primary key references auth.users(id) on delete cascade,
+  email text,
+  profile jsonb,
+  pressure_calibration jsonb,
+  onboarding_complete boolean not null default false,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists public.tasks (
+  id text primary key,
+  user_id uuid not null references auth.users(id) on delete cascade,
+  data jsonb not null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists public.goals (
+  id text primary key,
+  user_id uuid not null references auth.users(id) on delete cascade,
+  data jsonb not null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists public.pressure_logs (
+  id text primary key,
+  user_id uuid not null references auth.users(id) on delete cascade,
+  data jsonb not null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists tasks_user_id_idx on public.tasks(user_id);
+create index if not exists goals_user_id_idx on public.goals(user_id);
+create index if not exists pressure_logs_user_id_idx on public.pressure_logs(user_id);
+
+alter table public.profiles enable row level security;
+alter table public.tasks enable row level security;
+alter table public.goals enable row level security;
+alter table public.pressure_logs enable row level security;
+
+create policy "profiles_select_own" on public.profiles for select using (auth.uid() = user_id);
+create policy "profiles_insert_own" on public.profiles for insert with check (auth.uid() = user_id);
+create policy "profiles_update_own" on public.profiles for update using (auth.uid() = user_id) with check (auth.uid() = user_id);
+create policy "profiles_delete_own" on public.profiles for delete using (auth.uid() = user_id);
+
+create policy "tasks_select_own" on public.tasks for select using (auth.uid() = user_id);
+create policy "tasks_insert_own" on public.tasks for insert with check (auth.uid() = user_id);
+create policy "tasks_update_own" on public.tasks for update using (auth.uid() = user_id) with check (auth.uid() = user_id);
+create policy "tasks_delete_own" on public.tasks for delete using (auth.uid() = user_id);
+
+create policy "goals_select_own" on public.goals for select using (auth.uid() = user_id);
+create policy "goals_insert_own" on public.goals for insert with check (auth.uid() = user_id);
+create policy "goals_update_own" on public.goals for update using (auth.uid() = user_id) with check (auth.uid() = user_id);
+create policy "goals_delete_own" on public.goals for delete using (auth.uid() = user_id);
+
+create policy "pressure_logs_select_own" on public.pressure_logs for select using (auth.uid() = user_id);
+create policy "pressure_logs_insert_own" on public.pressure_logs for insert with check (auth.uid() = user_id);
+create policy "pressure_logs_update_own" on public.pressure_logs for update using (auth.uid() = user_id) with check (auth.uid() = user_id);
+create policy "pressure_logs_delete_own" on public.pressure_logs for delete using (auth.uid() = user_id);


### PR DESCRIPTION
### Motivation
- Provide a minimal Supabase-backed auth and cloud sync MVP so users can sign up / sign in and optionally sync their tasks/goals/pressure history to the cloud. 
- Preserve the existing localStorage-first behavior and offer an explicit guest/local mode so current users are not forced into cloud sync. 
- Ensure user data isolation by scoping cloud reads/writes to the Supabase `auth.uid()` and by including an SQL migration that enables RLS policies. 

### Description
- Added a lightweight Supabase client that reads only public Vite env vars (`VITE_SUPABASE_URL`, `VITE_SUPABASE_ANON_KEY`) and implements email/password `signUp`, `signInWithPassword`, session persistence and a simple `rest` helper: `src/lib/supabaseClient.ts`.
- Added a React hook `useSupabaseAuth` to expose `session`, `isLoading`, `error`, `signIn`, `signUp`, and `signOut`: `src/hooks/useSupabaseAuth.ts` and a UI `AuthPanel` for sign-in / sign-up / continue-as-guest flows: `src/components/AuthPanel.tsx`.
- Implemented a cloud sync layer that loads and writes JSON rows for `tasks`, `goals`, `pressure_logs`, and `profiles` (profile + pressure calibration + onboarding flag), merges local/imported data on login, and writes back changes to Supabase: `src/lib/cloudSync.ts`.
- Integrated auth and sync into the app shell (`src/App.tsx`) so unauthenticated users see the auth panel unless they choose guest mode, and authenticated users trigger a merge-from-cloud then automatic cloud writes for tasks/goals/pressure history/profile.
- Added a SQL migration file `supabase-schema.sql` that creates `profiles`, `tasks`, `goals`, and `pressure_logs`, creates indexes, enables Row Level Security, and adds policies that restrict select/insert/update/delete to rows where `auth.uid() = user_id`.

### Testing
- Ran a production build with `npm run build`, which completed successfully and generated the `dist` output without TypeScript or bundling errors.
- Ran `git diff --check` which reported no whitespace or diff-check issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08b905b1b8832cbd8ecf5a0a386b32)