### PR TITLE
Fix Supabase auth environment handling

### DIFF
--- a/src/components/AuthPanel.tsx
+++ b/src/components/AuthPanel.tsx
@@ -43,8 +43,8 @@ export function AuthPanel({ isConfigured, isLoading, error, onSignIn, onSignUp, 
         <h1 className="mt-3 text-3xl font-semibold tracking-tight text-slate-950">登录以启用云同步</h1>
         <p className="mt-3 text-sm leading-6 text-slate-500">使用 Supabase 邮箱密码登录后，任务、目标与压力历史会按你的用户 ID 隔离同步。也可以继续使用本机 localStorage。</p>
 
-        {!isConfigured ? (
-          <p className="mt-5 rounded-2xl bg-amber-50 px-4 py-3 text-sm text-amber-700 ring-1 ring-amber-100">当前缺少 VITE_SUPABASE_URL 或 VITE_SUPABASE_ANON_KEY，云同步不可用。</p>
+        {!isConfigured && !error ? (
+          <p className="mt-5 rounded-2xl bg-amber-50 px-4 py-3 text-sm text-amber-700 ring-1 ring-amber-100">Supabase environment variables are missing.</p>
         ) : null}
         {isLoading ? <p className="mt-5 rounded-2xl bg-sky-50 px-4 py-3 text-sm text-sky-700 ring-1 ring-sky-100">正在恢复登录状态…</p> : null}
         {error || formError ? <p className="mt-5 rounded-2xl bg-rose-50 px-4 py-3 text-sm text-rose-600 ring-1 ring-rose-100">{formError || error}</p> : null}

--- a/src/hooks/useSupabaseAuth.ts
+++ b/src/hooks/useSupabaseAuth.ts
@@ -28,14 +28,14 @@ export function useSupabaseAuth() {
 
   const signUp = useCallback(async (email: string, password: string) => {
     setError(undefined);
-    const nextSession = await supabase.auth.signUp(email, password);
+    const nextSession = await supabase.auth.signUp({ email, password });
     if (nextSession) setSession(nextSession);
     return nextSession;
   }, []);
 
   const signIn = useCallback(async (email: string, password: string) => {
     setError(undefined);
-    const nextSession = await supabase.auth.signInWithPassword(email, password);
+    const nextSession = await supabase.auth.signInWithPassword({ email, password });
     setSession(nextSession);
     return nextSession;
   }, []);
@@ -46,5 +46,5 @@ export function useSupabaseAuth() {
     setSession(null);
   }, []);
 
-  return { session, isLoading, error, isConfigured: supabase.isConfigured, signUp, signIn, signOut };
+  return { session, isLoading, error: error ?? supabase.configError, isConfigured: supabase.isConfigured, signUp, signIn, signOut };
 }

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -12,15 +12,76 @@ export interface SupabaseSession {
 
 type AuthChangeCallback = (session: SupabaseSession | null) => void;
 
-const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL as string | undefined;
-const SUPABASE_ANON_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY as string | undefined;
-const SESSION_STORAGE_KEY = 'vd.supabase.session';
+interface EmailPasswordCredentials {
+  email: string;
+  password: string;
+}
 
-function getRequiredConfig() {
-  if (!SUPABASE_URL || !SUPABASE_ANON_KEY) {
-    throw new Error('缺少 Supabase 环境变量：请配置 VITE_SUPABASE_URL 和 VITE_SUPABASE_ANON_KEY。');
+const RAW_SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL as string | undefined;
+const RAW_SUPABASE_ANON_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY as string | undefined;
+const SESSION_STORAGE_KEY = 'vd.supabase.session';
+const MISSING_CONFIG_MESSAGE = 'Supabase environment variables are missing.';
+const INVALID_URL_MESSAGE = 'Supabase URL must be a valid project base URL.';
+const SUPABASE_PATH_SUFFIX_PATTERN = /\/(?:rest|auth)\/v1\/?$/i;
+
+interface SupabaseConfig {
+  url: string;
+  anonKey: string;
+}
+
+interface SupabaseConfigStatus {
+  config?: SupabaseConfig;
+  error?: string;
+}
+
+function normalizeSupabaseUrl(rawUrl: string): string {
+  let normalizedUrl = rawUrl.trim();
+  while (SUPABASE_PATH_SUFFIX_PATTERN.test(normalizedUrl)) {
+    normalizedUrl = normalizedUrl.replace(SUPABASE_PATH_SUFFIX_PATTERN, '');
   }
-  return { url: SUPABASE_URL.replace(/\/$/, ''), anonKey: SUPABASE_ANON_KEY };
+  return normalizedUrl.replace(/\/+$/, '');
+}
+
+function getSupabaseConfigStatus(): SupabaseConfigStatus {
+  const anonKey = RAW_SUPABASE_ANON_KEY?.trim();
+  if (!RAW_SUPABASE_URL?.trim() || !anonKey) {
+    return { error: MISSING_CONFIG_MESSAGE };
+  }
+
+  const url = normalizeSupabaseUrl(RAW_SUPABASE_URL);
+  try {
+    const parsedUrl = new URL(url);
+    if (!['http:', 'https:'].includes(parsedUrl.protocol) || parsedUrl.pathname !== '/') {
+      return { error: INVALID_URL_MESSAGE };
+    }
+    return { config: { url: parsedUrl.origin, anonKey } };
+  } catch {
+    return { error: INVALID_URL_MESSAGE };
+  }
+}
+
+const supabaseConfigStatus = getSupabaseConfigStatus();
+
+if (import.meta.env.DEV) {
+  const debugUrl = supabaseConfigStatus.config?.url ?? (RAW_SUPABASE_URL?.trim() ? normalizeSupabaseUrl(RAW_SUPABASE_URL) : undefined);
+  let urlOrigin: string | undefined;
+  try {
+    urlOrigin = debugUrl ? new URL(debugUrl).origin : undefined;
+  } catch {
+    urlOrigin = undefined;
+  }
+  console.debug('[Visual Deadline Supabase]', {
+    hasUrl: Boolean(RAW_SUPABASE_URL?.trim()),
+    hasAnonKey: Boolean(RAW_SUPABASE_ANON_KEY?.trim()),
+    urlOrigin,
+  });
+}
+
+function getRequiredConfig(): SupabaseConfig {
+  if (!supabaseConfigStatus.config) {
+    throw new Error(supabaseConfigStatus.error ?? MISSING_CONFIG_MESSAGE);
+  }
+  return supabaseConfigStatus.config;
 }
 
 function readStoredSession(): SupabaseSession | null {
@@ -62,7 +123,11 @@ class VisualDeadlineSupabaseClient {
   private listeners = new Set<AuthChangeCallback>();
 
   get isConfigured(): boolean {
-    return Boolean(SUPABASE_URL && SUPABASE_ANON_KEY);
+    return Boolean(supabaseConfigStatus.config);
+  }
+
+  get configError(): string | undefined {
+    return supabaseConfigStatus.error;
   }
 
   auth = {
@@ -74,7 +139,7 @@ class VisualDeadlineSupabaseClient {
       }
       return stored;
     },
-    signUp: async (email: string, password: string): Promise<SupabaseSession | null> => {
+    signUp: async ({ email, password }: EmailPasswordCredentials): Promise<SupabaseSession | null> => {
       const { url, anonKey } = getRequiredConfig();
       const payload = await parseResponse<{ access_token?: string; refresh_token?: string; expires_in?: number; user: SupabaseUser }>(await fetch(`${url}/auth/v1/signup`, {
         method: 'POST',
@@ -87,7 +152,7 @@ class VisualDeadlineSupabaseClient {
       this.emit(session);
       return session;
     },
-    signInWithPassword: async (email: string, password: string): Promise<SupabaseSession> => {
+    signInWithPassword: async ({ email, password }: EmailPasswordCredentials): Promise<SupabaseSession> => {
       const { url, anonKey } = getRequiredConfig();
       const payload = await parseResponse<{ access_token: string; refresh_token: string; expires_in?: number; user: SupabaseUser }>(await fetch(`${url}/auth/v1/token?grant_type=password`, {
         method: 'POST',


### PR DESCRIPTION
### Motivation
- Fix the signup/signin failure caused by malformed Supabase request URLs and ensure the app reads Supabase credentials correctly from Vite env vars while avoiding leaking secrets.

### Description
- Normalize and validate Vite env config in `src/lib/supabaseClient.ts`: read `import.meta.env.VITE_SUPABASE_URL` and `import.meta.env.VITE_SUPABASE_ANON_KEY`, strip accidental `/rest/v1` or `/auth/v1` suffixes, and expose a clear config error when values are missing or invalid.
- Add development-only debug that logs presence of URL/key and the URL origin only (never prints the anon key), and expose `supabase.configError` and `supabase.isConfigured` for UI consumption.
- Keep auth/rest communication targeting the sanitized project origin and existing Supabase endpoints (`${url}/auth/v1/signup`, `${url}/auth/v1/token?...`, `${url}/rest/v1/...`), and preserve the localStorage-backed session fallback and REST sync behavior.
- Update call sites: change `useSupabaseAuth` to call the updated auth shape (`supabase.auth.signUp({ email, password })` and `supabase.auth.signInWithPassword({ email, password })`) and surface `supabase.configError` as the hook `error`; update `AuthPanel` to show a clear message when env vars are missing.

Files changed:
- `src/lib/supabaseClient.ts` (env reading, normalization, validation, debug, API shapes)
- `src/hooks/useSupabaseAuth.ts` (call-site updates and error propagation)
- `src/components/AuthPanel.tsx` (user-facing missing-config message)

Required Vercel env vars:
- `VITE_SUPABASE_URL=https://<your-project>.supabase.co` (project base URL only; do NOT include `/rest/v1` or `/auth/v1`).
- `VITE_SUPABASE_ANON_KEY=sb_publishable_...` (publishable/anon key only; never put a service-role/secret key in a browser-exposed var).

Why the original bug happened:
- If the configured base URL already included `/auth/v1` or `/rest/v1`, the app appended those segments again and produced malformed paths like `/auth/v1/auth/v1/signup`, which Supabase rejects with `Invalid path specified in request URL`.

How to test registration manually:
1. Set the Vercel env vars `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY` and redeploy so Vite bakes them into the client bundle.
2. Open the app, go to Register, enter an email and a >=6 character password.
3. Confirm in DevTools → Network that the request is sent to `https://<your-project>.supabase.co/auth/v1/signup` and the flow succeeds (or shows email confirmation instructions if you require confirmation).

### Testing
- Ran a project-wide search for Supabase/env usage with `rg` and verified only the intended files reference the Vite vars, which succeeded.
- Performed a production build with `npm run build` and the build completed successfully.
- Verified the changed files are staged/committed and the repository status is clean.

All automated checks listed above succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0930fcdcec832cbed6094f1876ce64)