### PR TITLE
Fix Supabase cloud sync schema alignment

### DIFF
--- a/src/lib/cloudSync.ts
+++ b/src/lib/cloudSync.ts
@@ -1,17 +1,25 @@
 import type { Goal, PressureCalibrationSnapshot, PressureHistoryRecord, Task, UserProfile } from '../types/task';
-import { supabase, type SupabaseSession } from './supabaseClient';
+import { SupabaseRestError, supabase, type SupabaseSession } from './supabaseClient';
 
 interface JsonRow<T> {
   id: string;
+  user_id: string;
   data: T;
   updated_at?: string;
 }
 
-interface ProfileRow {
-  user_id: string;
+interface ProfileData {
   profile: UserProfile | null;
-  pressure_calibration: PressureCalibrationSnapshot | null;
-  onboarding_complete: boolean;
+  pressureCalibration: PressureCalibrationSnapshot | null;
+  onboardingComplete: boolean | null;
+}
+
+interface ProfileRow {
+  id: string;
+  user_id: string;
+  email: string | null;
+  display_name: string | null;
+  data: ProfileData | null;
   updated_at?: string;
 }
 
@@ -26,12 +34,55 @@ export interface CloudData {
 
 const encode = (value: string) => encodeURIComponent(value).replace(/'/g, '%27');
 
+const TABLE_OR_COLUMN_MISSING_PATTERNS = [
+  /relation .* does not exist/i,
+  /table .* does not exist/i,
+  /column .* does not exist/i,
+  /could not find .* in the schema cache/i,
+  /schema cache/i,
+];
+
+const RLS_DENIED_PATTERNS = [
+  /permission denied/i,
+  /row-level security/i,
+  /violates row-level security policy/i,
+  /not authorized/i,
+];
+
+function formatCloudSyncError(error: unknown): Error {
+  if (!(error instanceof Error)) return new Error('云同步失败。');
+
+  const details = error instanceof SupabaseRestError
+    ? [error.message, error.code, error.details, error.hint, String(error.status)].filter(Boolean).join(' ')
+    : error.message;
+
+  console.error('[Visual Deadline cloud sync error]', error);
+
+  if (TABLE_OR_COLUMN_MISSING_PATTERNS.some((pattern) => pattern.test(details))) {
+    return new Error('Database schema is not initialized. Run supabase-schema.sql.');
+  }
+
+  if (RLS_DENIED_PATTERNS.some((pattern) => pattern.test(details)) || (error instanceof SupabaseRestError && [401, 403].includes(error.status))) {
+    return new Error('Cloud sync permission denied. Check RLS policies.');
+  }
+
+  return error;
+}
+
+async function withCloudSyncErrors<T>(operation: Promise<T>): Promise<T> {
+  try {
+    return await operation;
+  } catch (error) {
+    throw formatCloudSyncError(error);
+  }
+}
+
 function rowFromEntity<T extends { id: string }>(entity: T, userId: string) {
   return { id: entity.id, user_id: userId, data: entity, updated_at: new Date().toISOString() };
 }
 
 async function loadJsonRows<T>(table: 'tasks' | 'goals' | 'pressure_logs', session: SupabaseSession): Promise<T[]> {
-  const rows = await supabase.rest<JsonRow<T>[]>(`${table}?select=id,data,updated_at&user_id=eq.${encode(session.user.id)}`, { method: 'GET' }, session);
+  const rows = await supabase.rest<JsonRow<T>[]>(`${table}?select=id,user_id,data,updated_at&user_id=eq.${encode(session.user.id)}`, { method: 'GET' }, session);
   return rows.map((row) => row.data).filter(Boolean);
 }
 
@@ -40,52 +91,58 @@ async function replaceJsonRows<T extends { id: string }>(table: 'tasks' | 'goals
   if (values.length === 0) return;
   await supabase.rest(table, {
     method: 'POST',
-    headers: { Prefer: 'resolution=merge-duplicates' },
+    headers: { Prefer: 'resolution=merge-duplicates,return=minimal' },
     body: JSON.stringify(values.map((value) => rowFromEntity(value, session.user.id))),
   }, session);
 }
 
 export async function loadCloudData(session: SupabaseSession): Promise<CloudData> {
-  const [tasks, goals, pressureHistory, profiles] = await Promise.all([
-    loadJsonRows<Task>('tasks', session),
-    loadJsonRows<Goal>('goals', session),
-    loadJsonRows<PressureHistoryRecord>('pressure_logs', session),
-    supabase.rest<ProfileRow[]>(`profiles?select=user_id,profile,pressure_calibration,onboarding_complete&user_id=eq.${encode(session.user.id)}&limit=1`, { method: 'GET' }, session),
-  ]);
-  const profile = profiles[0];
-  return {
-    tasks,
-    goals,
-    pressureHistory,
-    profile: profile?.profile ?? null,
-    pressureCalibration: profile?.pressure_calibration ?? null,
-    onboardingComplete: typeof profile?.onboarding_complete === 'boolean' ? profile.onboarding_complete : null,
-  };
+  return withCloudSyncErrors((async () => {
+    const [tasks, goals, pressureHistory, profiles] = await Promise.all([
+      loadJsonRows<Task>('tasks', session),
+      loadJsonRows<Goal>('goals', session),
+      loadJsonRows<PressureHistoryRecord>('pressure_logs', session),
+      supabase.rest<ProfileRow[]>(`profiles?select=id,user_id,email,display_name,data,updated_at&user_id=eq.${encode(session.user.id)}&limit=1`, { method: 'GET' }, session),
+    ]);
+    const profileData = profiles[0]?.data;
+    return {
+      tasks,
+      goals,
+      pressureHistory,
+      profile: profileData?.profile ?? null,
+      pressureCalibration: profileData?.pressureCalibration ?? null,
+      onboardingComplete: typeof profileData?.onboardingComplete === 'boolean' ? profileData.onboardingComplete : null,
+    };
+  })());
 }
 
 export async function saveCloudTasks(tasks: Task[], session: SupabaseSession): Promise<void> {
-  await replaceJsonRows('tasks', tasks, session);
+  await withCloudSyncErrors(replaceJsonRows('tasks', tasks, session));
 }
 
 export async function saveCloudGoals(goals: Goal[], session: SupabaseSession): Promise<void> {
-  await replaceJsonRows('goals', goals, session);
+  await withCloudSyncErrors(replaceJsonRows('goals', goals, session));
 }
 
 export async function saveCloudPressureHistory(records: PressureHistoryRecord[], session: SupabaseSession): Promise<void> {
-  await replaceJsonRows('pressure_logs', records, session);
+  await withCloudSyncErrors(replaceJsonRows('pressure_logs', records, session));
 }
 
 export async function saveCloudProfile(input: { profile: UserProfile; pressureCalibration: PressureCalibrationSnapshot; onboardingComplete: boolean }, session: SupabaseSession): Promise<void> {
-  await supabase.rest('profiles', {
+  await withCloudSyncErrors(supabase.rest('profiles', {
     method: 'POST',
-    headers: { Prefer: 'resolution=merge-duplicates' },
+    headers: { Prefer: 'resolution=merge-duplicates,return=minimal' },
     body: JSON.stringify({
+      id: session.user.id,
       user_id: session.user.id,
       email: session.user.email ?? null,
-      profile: input.profile,
-      pressure_calibration: input.pressureCalibration,
-      onboarding_complete: input.onboardingComplete,
+      display_name: input.profile.nickname || null,
+      data: {
+        profile: input.profile,
+        pressureCalibration: input.pressureCalibration,
+        onboardingComplete: input.onboardingComplete,
+      },
       updated_at: new Date().toISOString(),
     }),
-  }, session);
+  }, session));
 }

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -12,6 +12,22 @@ export interface SupabaseSession {
 
 type AuthChangeCallback = (session: SupabaseSession | null) => void;
 
+export class SupabaseRestError extends Error {
+  status: number;
+  code?: string;
+  details?: string;
+  hint?: string;
+
+  constructor(message: string, response: Response, body: Record<string, unknown> | null) {
+    super(message);
+    this.name = 'SupabaseRestError';
+    this.status = response.status;
+    this.code = typeof body?.code === 'string' ? body.code : undefined;
+    this.details = typeof body?.details === 'string' ? body.details : undefined;
+    this.hint = typeof body?.hint === 'string' ? body.hint : undefined;
+  }
+}
+
 interface EmailPasswordCredentials {
   email: string;
   password: string;
@@ -114,7 +130,14 @@ async function parseResponse<T>(response: Response): Promise<T> {
   const body = text ? JSON.parse(text) : null;
   if (!response.ok) {
     const message = body?.msg || body?.message || body?.error_description || body?.error || 'Supabase 请求失败。';
-    throw new Error(message);
+    if (import.meta.env.DEV) {
+      console.error('[Visual Deadline Supabase REST error]', {
+        status: response.status,
+        statusText: response.statusText,
+        body,
+      });
+    }
+    throw new SupabaseRestError(message, response, body && typeof body === 'object' ? body as Record<string, unknown> : null);
   }
   return body as T;
 }

--- a/supabase-schema.sql
+++ b/supabase-schema.sql
@@ -1,65 +1,184 @@
--- Visual Deadline Supabase MVP schema
--- Run this in the Supabase SQL editor for the project used by VITE_SUPABASE_URL.
+-- Visual Deadline clean Supabase cloud-sync schema
+-- Run this whole file in the Supabase SQL Editor for the project used by VITE_SUPABASE_URL.
+-- It intentionally drops and recreates only the Visual Deadline app tables below.
 
-create table if not exists public.profiles (
-  user_id uuid primary key references auth.users(id) on delete cascade,
+begin;
+
+drop table if exists public.pressure_logs cascade;
+drop table if exists public.goals cascade;
+drop table if exists public.tasks cascade;
+drop table if exists public.profiles cascade;
+
+drop function if exists public.set_visual_deadline_updated_at() cascade;
+
+create function public.set_visual_deadline_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+create table public.profiles (
+  id uuid primary key references auth.users(id) on delete cascade,
+  user_id uuid not null unique references auth.users(id) on delete cascade,
   email text,
-  profile jsonb,
-  pressure_calibration jsonb,
-  onboarding_complete boolean not null default false,
+  display_name text,
+  data jsonb not null default '{}'::jsonb,
   created_at timestamptz not null default now(),
-  updated_at timestamptz not null default now()
+  updated_at timestamptz not null default now(),
+  constraint profiles_id_user_id_match check (id = user_id)
 );
 
-create table if not exists public.tasks (
+create table public.tasks (
   id text primary key,
   user_id uuid not null references auth.users(id) on delete cascade,
-  data jsonb not null,
+  data jsonb not null default '{}'::jsonb,
   created_at timestamptz not null default now(),
   updated_at timestamptz not null default now()
 );
 
-create table if not exists public.goals (
+create table public.goals (
   id text primary key,
   user_id uuid not null references auth.users(id) on delete cascade,
-  data jsonb not null,
+  data jsonb not null default '{}'::jsonb,
   created_at timestamptz not null default now(),
   updated_at timestamptz not null default now()
 );
 
-create table if not exists public.pressure_logs (
+create table public.pressure_logs (
   id text primary key,
   user_id uuid not null references auth.users(id) on delete cascade,
-  data jsonb not null,
+  data jsonb not null default '{}'::jsonb,
   created_at timestamptz not null default now(),
   updated_at timestamptz not null default now()
 );
 
-create index if not exists tasks_user_id_idx on public.tasks(user_id);
-create index if not exists goals_user_id_idx on public.goals(user_id);
-create index if not exists pressure_logs_user_id_idx on public.pressure_logs(user_id);
+create index tasks_user_id_idx on public.tasks(user_id);
+create index goals_user_id_idx on public.goals(user_id);
+create index pressure_logs_user_id_idx on public.pressure_logs(user_id);
+
+create trigger profiles_set_updated_at
+before update on public.profiles
+for each row execute function public.set_visual_deadline_updated_at();
+
+create trigger tasks_set_updated_at
+before update on public.tasks
+for each row execute function public.set_visual_deadline_updated_at();
+
+create trigger goals_set_updated_at
+before update on public.goals
+for each row execute function public.set_visual_deadline_updated_at();
+
+create trigger pressure_logs_set_updated_at
+before update on public.pressure_logs
+for each row execute function public.set_visual_deadline_updated_at();
 
 alter table public.profiles enable row level security;
 alter table public.tasks enable row level security;
 alter table public.goals enable row level security;
 alter table public.pressure_logs enable row level security;
 
-create policy "profiles_select_own" on public.profiles for select using (auth.uid() = user_id);
-create policy "profiles_insert_own" on public.profiles for insert with check (auth.uid() = user_id);
-create policy "profiles_update_own" on public.profiles for update using (auth.uid() = user_id) with check (auth.uid() = user_id);
-create policy "profiles_delete_own" on public.profiles for delete using (auth.uid() = user_id);
+create policy profiles_select_own
+on public.profiles
+for select
+to authenticated
+using (auth.uid() = id and auth.uid() = user_id);
 
-create policy "tasks_select_own" on public.tasks for select using (auth.uid() = user_id);
-create policy "tasks_insert_own" on public.tasks for insert with check (auth.uid() = user_id);
-create policy "tasks_update_own" on public.tasks for update using (auth.uid() = user_id) with check (auth.uid() = user_id);
-create policy "tasks_delete_own" on public.tasks for delete using (auth.uid() = user_id);
+create policy profiles_insert_own
+on public.profiles
+for insert
+to authenticated
+with check (auth.uid() = id and auth.uid() = user_id);
 
-create policy "goals_select_own" on public.goals for select using (auth.uid() = user_id);
-create policy "goals_insert_own" on public.goals for insert with check (auth.uid() = user_id);
-create policy "goals_update_own" on public.goals for update using (auth.uid() = user_id) with check (auth.uid() = user_id);
-create policy "goals_delete_own" on public.goals for delete using (auth.uid() = user_id);
+create policy profiles_update_own
+on public.profiles
+for update
+to authenticated
+using (auth.uid() = id and auth.uid() = user_id)
+with check (auth.uid() = id and auth.uid() = user_id);
 
-create policy "pressure_logs_select_own" on public.pressure_logs for select using (auth.uid() = user_id);
-create policy "pressure_logs_insert_own" on public.pressure_logs for insert with check (auth.uid() = user_id);
-create policy "pressure_logs_update_own" on public.pressure_logs for update using (auth.uid() = user_id) with check (auth.uid() = user_id);
-create policy "pressure_logs_delete_own" on public.pressure_logs for delete using (auth.uid() = user_id);
+create policy profiles_delete_own
+on public.profiles
+for delete
+to authenticated
+using (auth.uid() = id and auth.uid() = user_id);
+
+create policy tasks_select_own
+on public.tasks
+for select
+to authenticated
+using (auth.uid() = user_id);
+
+create policy tasks_insert_own
+on public.tasks
+for insert
+to authenticated
+with check (auth.uid() = user_id);
+
+create policy tasks_update_own
+on public.tasks
+for update
+to authenticated
+using (auth.uid() = user_id)
+with check (auth.uid() = user_id);
+
+create policy tasks_delete_own
+on public.tasks
+for delete
+to authenticated
+using (auth.uid() = user_id);
+
+create policy goals_select_own
+on public.goals
+for select
+to authenticated
+using (auth.uid() = user_id);
+
+create policy goals_insert_own
+on public.goals
+for insert
+to authenticated
+with check (auth.uid() = user_id);
+
+create policy goals_update_own
+on public.goals
+for update
+to authenticated
+using (auth.uid() = user_id)
+with check (auth.uid() = user_id);
+
+create policy goals_delete_own
+on public.goals
+for delete
+to authenticated
+using (auth.uid() = user_id);
+
+create policy pressure_logs_select_own
+on public.pressure_logs
+for select
+to authenticated
+using (auth.uid() = user_id);
+
+create policy pressure_logs_insert_own
+on public.pressure_logs
+for insert
+to authenticated
+with check (auth.uid() = user_id);
+
+create policy pressure_logs_update_own
+on public.pressure_logs
+for update
+to authenticated
+using (auth.uid() = user_id)
+with check (auth.uid() = user_id);
+
+create policy pressure_logs_delete_own
+on public.pressure_logs
+for delete
+to authenticated
+using (auth.uid() = user_id);
+
+commit;


### PR DESCRIPTION
### Motivation
- Cloud sync was failing because the frontend expected JSON `data` payload rows and a `user_id` ownership pattern while the deployed DB/schema and RLS policies did not match, causing errors like `column tasks.data does not exist`, `column profiles.user_id does not exist`, and `permission denied for table goals`.
- The change standardizes the app-side Supabase contract so the frontend, REST client, and DB schema/policies all agree on table shapes and RLS ownership checks.

### Description
- Aligned cloud-sync code paths and added robust error mapping by updating `src/lib/cloudSync.ts` to always read/write rows with `user_id` and `data jsonb`, wrap network calls with `withCloudSyncErrors`, and map missing-table/column and RLS errors to clear user messages.
- Added structured REST errors in `src/lib/supabaseClient.ts` by introducing `SupabaseRestError` and logging REST responses in dev mode to help distinguish schema vs permission failures.
- Replaced the previous schema with a single clean file `supabase-schema.sql` that drops and recreates `profiles`, `tasks`, `goals`, and `pressure_logs`, creates `data jsonb` columns, enforces `profiles.id = profiles.user_id`, installs `updated_at` triggers, enables RLS on every table, and creates owner-only select/insert/update/delete policies (tasks/goals/pressure_logs use `auth.uid() = user_id`; profiles requires `auth.uid() = id and auth.uid() = user_id`).
- Files changed: `src/lib/cloudSync.ts`, `src/lib/supabaseClient.ts`, and `supabase-schema.sql`.
- Exact SQL to run: execute the full `supabase-schema.sql` in the Supabase SQL Editor for the project backing `VITE_SUPABASE_URL`; the script begins a transaction, drops the four app tables and an existing helper function, recreates tables with `data jsonb`, adds triggers and indexes, enables RLS, and creates owner-only policies (the file is intentionally destructive to the app tables so export production data first if needed).
- Manual test flow after running the SQL: (1) run `supabase-schema.sql` in Supabase SQL Editor, (2) redeploy the frontend (Vercel), (3) register/login via Supabase Auth, (4) create a task, (5) refresh and confirm the created task remains, and (6) open another browser/session, log in as same user and confirm the task syncs from Supabase.

### Testing
- Ran repository searches to locate Supabase usages and confirm alignment with the `data`/`user_id` pattern; the search completed successfully using `rg` over the source tree.
- Built the project with `npm run build`, which ran `tsc -b` and `vite build` and succeeded (no TypeScript/build errors).
- All changes were committed with message `Fix Supabase cloud sync schema alignment`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0949fb403c832c857d9c3f0a0d2358)