### PR TITLE
Add DeepSeek AI backend proxy and VD Cloud AI client

### DIFF
--- a/api/ai.js
+++ b/api/ai.js
@@ -1,0 +1,186 @@
+const MAX_MESSAGE_LENGTH = 12_000;
+const MAX_CONTEXT_LENGTH = 60_000;
+const MAX_REQUESTS_PER_USER_PER_DAY = 20;
+const DEEPSEEK_PROVIDER = 'deepseek';
+const SUPPORTED_MODES = new Set(['task_advice', 'daily_plan', 'pressure_analysis']);
+const dailyRequestCounts = new Map();
+
+function sendJson(response, status, body) {
+  response.status(status).setHeader('Content-Type', 'application/json');
+  response.end(JSON.stringify(body));
+}
+
+function readEnv(name, fallbackName) {
+  const value = process.env[name] || (fallbackName ? process.env[fallbackName] : undefined);
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function getBearerToken(request) {
+  const header = request.headers.authorization || request.headers.Authorization;
+  if (typeof header !== 'string') return '';
+  const match = header.match(/^Bearer\s+(.+)$/i);
+  return match?.[1]?.trim() || '';
+}
+
+async function readJsonBody(request) {
+  if (request.body && typeof request.body === 'object') return request.body;
+
+  const chunks = [];
+  for await (const chunk of request) chunks.push(Buffer.from(chunk));
+  const raw = Buffer.concat(chunks).toString('utf8');
+  return raw ? JSON.parse(raw) : {};
+}
+
+async function verifySupabaseToken(accessToken) {
+  const supabaseUrl = readEnv('SUPABASE_URL', 'VITE_SUPABASE_URL').replace(/\/+$/, '');
+  const supabaseAnonKey = readEnv('SUPABASE_ANON_KEY', 'VITE_SUPABASE_ANON_KEY');
+  if (!supabaseUrl || !supabaseAnonKey) throw new Error('SUPABASE_CONFIG_MISSING');
+
+  const response = await fetch(`${supabaseUrl}/auth/v1/user`, {
+    headers: {
+      apikey: supabaseAnonKey,
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
+
+  if (!response.ok) return null;
+  const user = await response.json();
+  return typeof user?.id === 'string' ? user : null;
+}
+
+function getUsageKey(userId) {
+  return `${userId}:${new Date().toISOString().slice(0, 10)}`;
+}
+
+function checkRateLimit(userId) {
+  // TODO: Move this placeholder limit to a Supabase table or another durable store.
+  // Vercel function memory is per warm instance and can reset/rebalance between invocations.
+  const key = getUsageKey(userId);
+  const used = dailyRequestCounts.get(key) || 0;
+  if (used >= MAX_REQUESTS_PER_USER_PER_DAY) return false;
+  dailyRequestCounts.set(key, used + 1);
+  return true;
+}
+
+function validatePayload(payload) {
+  if (!payload || typeof payload !== 'object') return '请求体必须是 JSON 对象。';
+  if (!SUPPORTED_MODES.has(payload.mode)) return 'mode 必须是 task_advice、daily_plan 或 pressure_analysis。';
+  if (typeof payload.message !== 'string' || !payload.message.trim()) return 'message 不能为空。';
+  if (payload.message.length > MAX_MESSAGE_LENGTH) return `message 不能超过 ${MAX_MESSAGE_LENGTH} 个字符。`;
+
+  if (payload.context !== undefined) {
+    if (!payload.context || typeof payload.context !== 'object' || Array.isArray(payload.context)) return 'context 必须是对象。';
+    const contextLength = JSON.stringify(payload.context).length;
+    if (contextLength > MAX_CONTEXT_LENGTH) return `context 不能超过 ${MAX_CONTEXT_LENGTH} 个字符。`;
+  }
+
+  return '';
+}
+
+function buildUserContent(payload) {
+  return JSON.stringify(
+    {
+      mode: payload.mode,
+      message: payload.message,
+      context: payload.context || {},
+    },
+    null,
+    2,
+  );
+}
+
+async function callDeepSeek(payload) {
+  const apiKey = readEnv('DEEPSEEK_API_KEY');
+  const baseUrl = readEnv('DEEPSEEK_BASE_URL') || 'https://api.deepseek.com';
+  const model = readEnv('DEEPSEEK_MODEL') || 'deepseek-chat';
+  const provider = readEnv('AI_PROVIDER') || DEEPSEEK_PROVIDER;
+
+  if (provider !== DEEPSEEK_PROVIDER) throw new Error('UNSUPPORTED_PROVIDER');
+  if (!apiKey) throw new Error('DEEPSEEK_API_KEY_MISSING');
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 30_000);
+
+  try {
+    const response = await fetch(`${baseUrl.replace(/\/+$/, '')}/chat/completions`, {
+      method: 'POST',
+      signal: controller.signal,
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        model,
+        messages: [
+          {
+            role: 'system',
+            content:
+              "You are Visual Deadline's AI planning assistant. Analyze task, goal, and pressure data only from the provided JSON. Be concise, practical, structured, and respond in Simplified Chinese unless the user asks otherwise. Never claim to modify data directly.",
+          },
+          { role: 'user', content: buildUserContent(payload) },
+        ],
+        temperature: 0.4,
+      }),
+    });
+
+    const rawText = await response.text();
+    let data;
+    try {
+      data = rawText ? JSON.parse(rawText) : undefined;
+    } catch {
+      data = undefined;
+    }
+
+    if (!response.ok) {
+      const upstreamMessage = typeof data?.error?.message === 'string' ? data.error.message : `DeepSeek returned ${response.status}`;
+      const error = new Error(upstreamMessage);
+      error.status = response.status;
+      throw error;
+    }
+
+    const content = data?.choices?.[0]?.message?.content?.trim();
+    if (!content) throw new Error('DeepSeek 未返回有效内容。');
+
+    return { content, model };
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+export default async function handler(request, response) {
+  if (request.method !== 'POST') {
+    response.setHeader('Allow', 'POST');
+    return sendJson(response, 405, { ok: false, error: '只支持 POST 请求。' });
+  }
+
+  try {
+    const accessToken = getBearerToken(request);
+    if (!accessToken) return sendJson(response, 401, { ok: false, error: '缺少 Supabase 登录凭证。' });
+
+    const user = await verifySupabaseToken(accessToken);
+    if (!user) return sendJson(response, 401, { ok: false, error: 'Supabase 登录凭证无效或已过期。' });
+
+    const payload = await readJsonBody(request);
+    const validationError = validatePayload(payload);
+    if (validationError) return sendJson(response, 400, { ok: false, error: validationError });
+
+    if (!checkRateLimit(user.id)) return sendJson(response, 429, { ok: false, error: '今日 AI 请求次数已达上限（20 次）。请明天再试。' });
+
+    const result = await callDeepSeek(payload);
+    return sendJson(response, 200, {
+      ok: true,
+      content: result.content,
+      model: result.model,
+      provider: DEEPSEEK_PROVIDER,
+    });
+  } catch (error) {
+    if (error?.message === 'SUPABASE_CONFIG_MISSING') return sendJson(response, 500, { ok: false, error: '服务端 Supabase 环境变量未配置。' });
+    if (error?.message === 'UNSUPPORTED_PROVIDER') return sendJson(response, 500, { ok: false, error: '当前服务端 AI_PROVIDER 暂不支持。' });
+    if (error?.message === 'DEEPSEEK_API_KEY_MISSING') return sendJson(response, 500, { ok: false, error: '服务端 DeepSeek API Key 未配置。' });
+    if (error?.name === 'AbortError') return sendJson(response, 504, { ok: false, error: 'AI 请求超时，请稍后重试。' });
+
+    const status = Number.isInteger(error?.status) && error.status >= 400 && error.status < 600 ? error.status : 500;
+    const message = error instanceof Error && error.message ? error.message : 'AI 服务暂时不可用，请稍后重试。';
+    return sendJson(response, status >= 500 ? 502 : status, { ok: false, error: message });
+  }
+}

--- a/docs/ai-backend.md
+++ b/docs/ai-backend.md
@@ -1,0 +1,131 @@
+# Visual Deadline AI Backend
+
+Visual Deadline uses a Vercel Serverless Function at `POST /api/ai` so logged-in users can use AI features without putting a provider API key in the browser.
+
+## Runtime behavior
+
+1. The frontend gets the current Supabase session and sends `Authorization: Bearer <supabase_access_token>` to `/api/ai`.
+2. The serverless function verifies the token by calling Supabase Auth (`/auth/v1/user`) from the backend.
+3. The function validates the AI payload and applies a simple placeholder rate limit of **20 AI requests per user per day**.
+4. The function calls DeepSeek's chat completions endpoint from the backend and returns only the generated content, model, and provider name.
+
+The browser never receives `DEEPSEEK_API_KEY`. Developer fallback mode still exists, but it only reads an API key saved in the user's local browser `localStorage`; Visual Deadline does not upload or store that key in Supabase.
+
+## Vercel environment variables
+
+Configure these variables in Vercel Project Settings → Environment Variables:
+
+| Variable | Example | Required | Notes |
+| --- | --- | --- | --- |
+| `AI_PROVIDER` | `deepseek` | Yes | Currently only `deepseek` is supported. |
+| `DEEPSEEK_API_KEY` | `sk-...` | Yes | Backend-only secret. Do **not** prefix with `VITE_`. |
+| `DEEPSEEK_BASE_URL` | `https://api.deepseek.com` | Yes | The function posts to `${DEEPSEEK_BASE_URL}/chat/completions`. |
+| `DEEPSEEK_MODEL` | `deepseek-chat` | Yes | DeepSeek chat model used by VD Cloud AI. |
+| `SUPABASE_URL` | `https://<project>.supabase.co` | Yes | Backend Supabase project URL used to verify sessions. Falls back to `VITE_SUPABASE_URL` if absent. |
+| `SUPABASE_ANON_KEY` | `<anon-key>` | Yes | Backend Supabase anon key used with the user's bearer token. Falls back to `VITE_SUPABASE_ANON_KEY` if absent. |
+
+The existing frontend variables `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY` are still needed by the React app for login and cloud sync.
+
+## API contract
+
+`POST /api/ai`
+
+Headers:
+
+```http
+Authorization: Bearer <supabase_access_token>
+Content-Type: application/json
+```
+
+Request body:
+
+```json
+{
+  "mode": "task_advice",
+  "message": "User prompt or structured prompt text",
+  "context": {
+    "tasks": [],
+    "goals": [],
+    "pressure": {}
+  }
+}
+```
+
+Supported `mode` values:
+
+- `task_advice`
+- `daily_plan`
+- `pressure_analysis`
+
+Successful response:
+
+```json
+{
+  "ok": true,
+  "content": "...",
+  "model": "deepseek-chat",
+  "provider": "deepseek"
+}
+```
+
+Error responses are frontend-safe JSON objects such as:
+
+```json
+{
+  "ok": false,
+  "error": "Supabase 登录凭证无效或已过期。"
+}
+```
+
+## Local testing
+
+1. Install dependencies:
+
+   ```bash
+   npm install
+   ```
+
+2. Create a local env file for Vite/Vercel development, for example `.env.local`:
+
+   ```bash
+   VITE_SUPABASE_URL=https://<project>.supabase.co
+   VITE_SUPABASE_ANON_KEY=<anon-key>
+   SUPABASE_URL=https://<project>.supabase.co
+   SUPABASE_ANON_KEY=<anon-key>
+   AI_PROVIDER=deepseek
+   DEEPSEEK_API_KEY=<deepseek-api-key>
+   DEEPSEEK_BASE_URL=https://api.deepseek.com
+   DEEPSEEK_MODEL=deepseek-chat
+   ```
+
+3. Run the Vercel dev server so `/api/ai` and Vite are available together:
+
+   ```bash
+   npx vercel dev
+   ```
+
+4. Log in through the app. AI features should show `VD Cloud AI 已启用` when no local developer API key is configured.
+
+5. Optional direct API smoke test after logging in and copying the Supabase access token from the browser's `vd.supabase.session` localStorage value:
+
+   ```bash
+   curl -i http://localhost:3000/api/ai \
+     -H 'Content-Type: application/json' \
+     -H 'Authorization: Bearer <supabase_access_token>' \
+     -d '{"mode":"task_advice","message":"给我一个今天的任务排序建议","context":{"tasks":[]}}'
+   ```
+
+## Vercel testing
+
+1. Add the environment variables listed above for the target Vercel environment (`Production`, `Preview`, or both).
+2. Redeploy the project after changing environment variables.
+3. Open the deployed app, log in with Supabase Auth, and run an AI feature.
+4. If the request fails, check the browser Network tab for `/api/ai` status codes:
+   - `401`: missing/expired Supabase session; log in again.
+   - `400`: invalid payload or too much input data.
+   - `429`: placeholder daily request limit reached for the user on the current function instance.
+   - `500`/`502`/`504`: missing backend environment variable, DeepSeek upstream error, or timeout.
+
+## Rate limit note
+
+The current 20-requests-per-user-per-day limit is intentionally a placeholder implemented in serverless function memory. It protects a warm instance but is not durable across cold starts or multiple Vercel instances. A production quota should be moved to a Supabase table or another durable store.

--- a/src/components/AIReviewPanel.tsx
+++ b/src/components/AIReviewPanel.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState } from 'react';
 import { useLocalStorage } from '../hooks/useLocalStorage';
 import { storageKeys } from '../storage';
 import type { AIArtifactInput, PressureHistoryRecord, Task } from '../types/task';
-import { defaultAISettings, normalizeAISettings, requestChatCompletion, type AISettings } from '../services/aiClient';
+import { defaultAISettings, getAIConnectionLabel, isDeveloperAIKeyMode, normalizeAISettings, requestChatCompletion, type AISettings } from '../services/aiClient';
 import { buildReviewUserPrompt, reviewSystemPrompt } from '../services/reviewPrompt';
 import { AIReportRenderer } from './AIReportRenderer';
 
@@ -20,14 +20,9 @@ export function AIReviewPanel({ tasks, pressureHistory, onAIReportGenerated }: A
   const [state, setState] = useState<ReviewState>('idle');
   const [report, setReport] = useState('');
   const [errorMessage, setErrorMessage] = useState('');
-  const hasApiKey = Boolean(settings.apiKey.trim());
+  const isDeveloperMode = isDeveloperAIKeyMode(settings);
 
   async function generateReview() {
-    if (!hasApiKey) {
-      setState('error');
-      setErrorMessage('请先在 AI 任务分析中设置 API Key，再生成近期数据观察。');
-      return;
-    }
     if (tasks.length === 0) {
       setState('error');
       setErrorMessage('当前没有任务数据，无法生成数据观察。');
@@ -37,7 +32,7 @@ export function AIReviewPanel({ tasks, pressureHistory, onAIReportGenerated }: A
     setState('loading');
     setErrorMessage('');
     try {
-      const result = await requestChatCompletion(settings, reviewSystemPrompt, buildReviewUserPrompt(tasks, pressureHistory));
+      const result = await requestChatCompletion(settings, reviewSystemPrompt, buildReviewUserPrompt(tasks, pressureHistory), { mode: 'pressure_analysis', context: { tasks, pressure: pressureHistory.at(-1) } });
       setReport(result);
       setState('success');
       onAIReportGenerated?.({
@@ -71,7 +66,7 @@ export function AIReviewPanel({ tasks, pressureHistory, onAIReportGenerated }: A
           {report ? <button type="button" onClick={() => { setReport(''); setErrorMessage(''); setState('idle'); }} className="rounded-full px-4 py-2 text-sm font-semibold text-slate-500 hover:bg-slate-100">隐藏本次结果</button> : null}
         </div>
       </div>
-      <div className="mt-4 rounded-2xl bg-slate-50/80 px-4 py-3 text-xs leading-5 text-slate-500 ring-1 ring-white/80">当前配置：{hasApiKey ? `${settings.provider} · ${settings.model}` : '未配置 API Key'}。数据观察仅发送必要任务与压力历史字段。</div>
+      <div className="mt-4 rounded-2xl bg-slate-50/80 px-4 py-3 text-xs leading-5 text-slate-500 ring-1 ring-white/80">当前配置：{getAIConnectionLabel(settings)}{isDeveloperMode ? ` · ${settings.provider} · ${settings.model}` : ''}。数据观察仅发送必要任务与压力历史字段。</div>
       {state === 'loading' ? <div className="mt-4 rounded-3xl bg-sky-50 p-5 text-sm font-semibold text-sky-700 ring-1 ring-sky-100">正在生成近期观察……</div> : null}
       {state === 'error' && errorMessage ? <div className="mt-4 rounded-3xl bg-rose-50 p-5 text-sm font-semibold text-rose-600 ring-1 ring-rose-100">{errorMessage}</div> : null}
       {report ? <AIReportRenderer content={report} variant="review" /> : null}

--- a/src/components/AITaskAnalysisPanel.tsx
+++ b/src/components/AITaskAnalysisPanel.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState, type FormEvent } from 'react';
 import { useLocalStorage } from '../hooks/useLocalStorage';
 import { storageKeys } from '../storage';
 import type { AIArtifactInput, PressureBreakdown, Task } from '../types/task';
-import { defaultAISettings, getProviderDefaults, normalizeAISettings, requestChatCompletion, type AIProvider, type AISettings } from '../services/aiClient';
+import { defaultAISettings, getAIConnectionLabel, getProviderDefaults, isDeveloperAIKeyMode, normalizeAISettings, requestChatCompletion, type AIProvider, type AISettings } from '../services/aiClient';
 import { buildTaskAnalysisUserPrompt, createTaskAnalysisPayload, taskAnalysisSystemPrompt } from '../services/taskAnalysisPrompt';
 import { AIReportRenderer } from './AIReportRenderer';
 import { ModalPortal } from './ModalPortal';
@@ -28,7 +28,7 @@ export function AITaskAnalysisPanel({ tasks, pressure, onAIConnected, onAIReport
   const [analysisState, setAnalysisState] = useState<AnalysisState>('idle');
   const [report, setReport] = useState('');
   const [errorMessage, setErrorMessage] = useState('');
-  const hasApiKey = Boolean(settings.apiKey.trim());
+  const isDeveloperMode = isDeveloperAIKeyMode(settings);
 
   function openSettings() {
     setDraftSettings(settings);
@@ -50,12 +50,6 @@ export function AITaskAnalysisPanel({ tasks, pressure, onAIConnected, onAIReport
   }
 
   async function runAnalysis() {
-    if (!hasApiKey) {
-      setErrorMessage('请先设置 AI API Key。');
-      setAnalysisState('error');
-      openSettings();
-      return;
-    }
     if (tasks.length === 0) {
       setErrorMessage('当前没有任务，无法进行 AI 任务分析。');
       setAnalysisState('error');
@@ -67,7 +61,7 @@ export function AITaskAnalysisPanel({ tasks, pressure, onAIConnected, onAIReport
     try {
       const payload = createTaskAnalysisPayload(tasks, pressure);
       const userPrompt = buildTaskAnalysisUserPrompt(payload);
-      const result = await requestChatCompletion(settings, taskAnalysisSystemPrompt, userPrompt);
+      const result = await requestChatCompletion(settings, taskAnalysisSystemPrompt, userPrompt, { mode: 'pressure_analysis', context: { tasks, pressure } });
       setReport(result);
       setAnalysisState('success');
       onAIReportGenerated?.({
@@ -96,7 +90,7 @@ export function AITaskAnalysisPanel({ tasks, pressure, onAIConnected, onAIReport
         </div>
         <div className="flex flex-wrap gap-2">
           <button type="button" onClick={openSettings} className="rounded-full bg-white/85 px-4 py-2 text-sm font-semibold text-slate-700 shadow-sm ring-1 ring-slate-200 hover:bg-slate-50">
-            设置 API Key
+            开发者 API Key
           </button>
           <button type="button" onClick={runAnalysis} disabled={analysisState === 'loading'} className="rounded-full bg-white/85 px-5 py-2 text-sm font-semibold text-slate-700 shadow-sm ring-1 ring-slate-200 hover:bg-slate-50 disabled:cursor-not-allowed disabled:text-slate-300">
             {report ? '重新分析' : '分析当前任务'}
@@ -106,14 +100,8 @@ export function AITaskAnalysisPanel({ tasks, pressure, onAIConnected, onAIReport
       </div>
 
       <div className="mt-4 rounded-2xl bg-slate-50/80 px-4 py-3 text-xs leading-5 text-slate-500 ring-1 ring-white/80">
-        <span className="font-semibold text-slate-600">当前配置：</span>{hasApiKey ? `${providerLabel(settings.provider)} · ${settings.model}` : '未配置 API Key'}。任务数据会直接发送给你选择的 AI 服务商用于生成分析。请不要填写不愿发送给第三方模型的敏感内容。
+        <span className="font-semibold text-slate-600">当前配置：</span>{getAIConnectionLabel(settings)}{isDeveloperMode ? ` · ${providerLabel(settings.provider)} · ${settings.model}` : ''}。默认通过 /api/ai 使用 VD Cloud AI，开发者本地 API Key 仅保存在当前浏览器。
       </div>
-
-      {!hasApiKey ? (
-        <div className="mt-4 rounded-3xl border border-dashed border-slate-200 bg-white/65 p-5 text-sm text-slate-500">
-          尚未配置 API Key。请先点击“设置 API Key”，配置后再分析当前任务。
-        </div>
-      ) : null}
 
       {analysisState === 'loading' ? <div className="mt-4 rounded-3xl bg-sky-50 p-5 text-sm font-semibold text-sky-700 ring-1 ring-sky-100">正在生成任务压力报告……</div> : null}
       {analysisState === 'error' && errorMessage ? <div className="mt-4 rounded-3xl bg-rose-50 p-5 text-sm font-semibold text-rose-600 ring-1 ring-rose-100">{errorMessage}</div> : null}
@@ -130,7 +118,7 @@ export function AITaskAnalysisPanel({ tasks, pressure, onAIConnected, onAIReport
               <button type="button" onClick={() => setIsSettingsOpen(false)} className="rounded-full bg-slate-100 px-3 py-1.5 text-xs font-semibold text-slate-500 hover:bg-slate-200">关闭</button>
             </div>
 
-            <p className="mt-4 rounded-2xl bg-slate-50 px-4 py-3 text-xs leading-5 text-slate-500 ring-1 ring-white/80">API Key 仅保存在当前浏览器本地，用于直接请求你选择的模型服务。VD 不会上传或保存你的 API Key 到服务器。</p>
+            <p className="mt-4 rounded-2xl bg-slate-50 px-4 py-3 text-xs leading-5 text-slate-500 ring-1 ring-white/80">开发者模式 API Key 仅保存在当前浏览器本地，用于绕过 VD Cloud AI 直接请求你选择的模型服务。普通用户无需配置 API Key，VD 不会上传或保存你的本地 API Key 到服务器。</p>
             <p className="mt-2 rounded-2xl bg-amber-50 px-4 py-3 text-xs leading-5 text-amber-700 ring-1 ring-amber-100">任务数据会直接发送给你选择的 AI 服务商用于生成分析。请不要填写不愿发送给第三方模型的敏感内容。</p>
 
             <div className="mt-5 grid gap-4 md:grid-cols-2">

--- a/src/components/AITaskCommandBar.tsx
+++ b/src/components/AITaskCommandBar.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState } from 'react';
 import { useLocalStorage } from '../hooks/useLocalStorage';
 import { storageKeys } from '../storage';
 import type { AIArtifactInput, Task, TaskInput } from '../types/task';
-import { defaultAISettings, normalizeAISettings, requestChatCompletion } from '../services/aiClient';
+import { defaultAISettings, getAIConnectionLabel, normalizeAISettings, requestChatCompletion } from '../services/aiClient';
 import type { AISettings } from '../services/aiClient';
 import { buildTaskIntakeUserPrompt, createTaskIntakePayload, parseTaskIntakeResponse, taskIntakeSystemPrompt } from '../services/taskIntakePrompt';
 import { getActivityTypeLabel } from '../utils/taskScoring';
@@ -31,15 +31,10 @@ export function AITaskCommandBar({ tasks, onConfirmTasks, onAIArtifactGenerated 
   const [notes, setNotes] = useState('');
   const [rawJson, setRawJson] = useState('');
   const [errorMessage, setErrorMessage] = useState('');
-  const hasApiKey = Boolean(settings.apiKey.trim());
+
 
   async function structureTasks() {
     const trimmedInput = input.trim();
-    if (!hasApiKey) {
-      setState('error');
-      setErrorMessage('请先在 AI 任务分析中设置 API Key，再使用 AI 任务录入。');
-      return;
-    }
     if (!trimmedInput) {
       setState('error');
       setErrorMessage('请先输入最近要做的事。');
@@ -53,7 +48,7 @@ export function AITaskCommandBar({ tasks, onConfirmTasks, onAIArtifactGenerated 
     setRawJson('');
     try {
       const payload = createTaskIntakePayload(trimmedInput, tasks);
-      const result = await requestChatCompletion(settings, taskIntakeSystemPrompt, buildTaskIntakeUserPrompt(payload));
+      const result = await requestChatCompletion(settings, taskIntakeSystemPrompt, buildTaskIntakeUserPrompt(payload), { mode: 'task_advice', context: { tasks } });
       const parsed = parseTaskIntakeResponse(result);
       setDrafts(parsed.tasks);
       setNotes(parsed.notes);
@@ -105,7 +100,7 @@ export function AITaskCommandBar({ tasks, onConfirmTasks, onAIArtifactGenerated 
           <h2 className="mt-1 text-2xl font-semibold">自然语言 → 可确认任务草稿</h2>
           <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-500">说出最近要推进的人生事项，AI 会抽取任务、阶段与拆解建议，确认后才会写入 VD。</p>
         </div>
-        <span className="rounded-full bg-slate-50 px-3 py-1.5 text-xs font-semibold text-slate-500 ring-1 ring-white/80">{hasApiKey ? '已配置 API Key' : '未配置 API Key'}</span>
+        <span className="rounded-full bg-slate-50 px-3 py-1.5 text-xs font-semibold text-slate-500 ring-1 ring-white/80">{getAIConnectionLabel(settings)}</span>
       </div>
 
       <div className="mt-5 flex flex-col gap-3 lg:flex-row">

--- a/src/components/GoalRoadmapPanel.tsx
+++ b/src/components/GoalRoadmapPanel.tsx
@@ -94,14 +94,10 @@ export function GoalRoadmapPanel({ goals, tasks, onSaveGoal, onDeleteGoal, onRoa
   }
 
   async function generateRoadmap(goal: Goal) {
-    if (!settings.apiKey.trim()) {
-      setRoadmapState({ errorGoalId: goal.id, message: '请先配置 AI API Key，再生成目标路线图。' });
-      return;
-    }
     setSelectedGoalId(goal.id);
     setRoadmapState({ loadingGoalId: goal.id });
     try {
-      const content = await requestChatCompletion(settings, goalRoadmapSystemPrompt, buildGoalRoadmapUserPrompt(goal, tasks));
+      const content = await requestChatCompletion(settings, goalRoadmapSystemPrompt, buildGoalRoadmapUserPrompt(goal, tasks), { mode: 'daily_plan', context: { goals: [goal], tasks } });
       const result = parseGoalRoadmapResponse(content);
       onSaveGoal({ ...createGoalInput(goal), roadmapSuggestions: result.roadmapSuggestions }, goal.id);
       onRoadmapGenerated?.({

--- a/src/services/aiClient.ts
+++ b/src/services/aiClient.ts
@@ -1,10 +1,35 @@
+import { supabase } from '../lib/supabaseClient';
+
 export type AIProvider = 'openai-compatible' | 'deepseek-compatible';
+export type BackendAIMode = 'task_advice' | 'daily_plan' | 'pressure_analysis';
 
 export interface AISettings {
   provider: AIProvider;
   baseUrl: string;
   apiKey: string;
   model: string;
+}
+
+export interface BackendAIRequest {
+  mode: BackendAIMode;
+  message: string;
+  context?: {
+    tasks?: unknown[];
+    goals?: unknown[];
+    pressure?: unknown;
+  };
+}
+
+export interface BackendAIResponse {
+  ok: true;
+  content: string;
+  model: string;
+  provider: 'deepseek';
+}
+
+interface RequestChatCompletionOptions {
+  mode?: BackendAIMode;
+  context?: BackendAIRequest['context'];
 }
 
 export const defaultAISettings: AISettings = {
@@ -30,6 +55,14 @@ export function normalizeAISettings(settings: Partial<AISettings> | null | undef
   };
 }
 
+export function isDeveloperAIKeyMode(settings: Partial<AISettings> | null | undefined): boolean {
+  return Boolean(settings?.apiKey?.trim());
+}
+
+export function getAIConnectionLabel(settings: Partial<AISettings> | null | undefined): string {
+  return isDeveloperAIKeyMode(settings) ? '开发者模式：使用本地 API Key' : 'VD Cloud AI 已启用';
+}
+
 interface ChatCompletionChoice {
   message?: { content?: string };
 }
@@ -39,7 +72,51 @@ interface ChatCompletionResponse {
   error?: { message?: string };
 }
 
-export async function requestChatCompletion(settings: AISettings, systemPrompt: string, userPrompt: string): Promise<string> {
+interface BackendAIErrorResponse {
+  ok?: false;
+  error?: string;
+}
+
+function buildBackendMessage(systemPrompt: string, userPrompt: string): string {
+  return JSON.stringify(
+    {
+      systemInstructions: systemPrompt,
+      userRequest: userPrompt,
+    },
+    null,
+    2,
+  );
+}
+
+export async function callBackendAI(request: BackendAIRequest): Promise<BackendAIResponse> {
+  const session = await supabase.auth.getSession();
+  if (!session?.access_token) throw new Error('请先登录后再使用 VD Cloud AI。');
+
+  const response = await fetch('/api/ai', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${session.access_token}`,
+    },
+    body: JSON.stringify(request),
+  });
+
+  let payload: BackendAIResponse | BackendAIErrorResponse | undefined;
+  try {
+    payload = (await response.json()) as BackendAIResponse | BackendAIErrorResponse;
+  } catch {
+    payload = undefined;
+  }
+
+  if (!response.ok || !payload?.ok) {
+    const message = payload && 'error' in payload && payload.error ? payload.error : `VD Cloud AI 请求失败：${response.status}`;
+    throw new Error(message);
+  }
+
+  return payload;
+}
+
+async function requestBrowserChatCompletion(settings: AISettings, systemPrompt: string, userPrompt: string): Promise<string> {
   const normalized = normalizeAISettings(settings);
   if (!normalized.apiKey.trim()) throw new Error('缺少 API Key，请先完成 AI 设置。');
   if (!normalized.baseUrl.trim()) throw new Error('缺少服务地址，请检查 AI 设置。');
@@ -77,4 +154,16 @@ export async function requestChatCompletion(settings: AISettings, systemPrompt: 
   const content = payload?.choices?.[0]?.message?.content?.trim();
   if (!content) throw new Error('AI 服务未返回有效分析内容。');
   return content;
+}
+
+export async function requestChatCompletion(settings: AISettings, systemPrompt: string, userPrompt: string, options: RequestChatCompletionOptions = {}): Promise<string> {
+  const normalized = normalizeAISettings(settings);
+  if (normalized.apiKey.trim()) return requestBrowserChatCompletion(normalized, systemPrompt, userPrompt);
+
+  const response = await callBackendAI({
+    mode: options.mode ?? 'task_advice',
+    message: buildBackendMessage(systemPrompt, userPrompt),
+    context: options.context,
+  });
+  return response.content;
 }


### PR DESCRIPTION
### Motivation
- Provide a VD Cloud AI path so end users can use AI features without entering an API key in the browser. 
- Allow the app owner to configure provider/model via server environment variables while never exposing backend API keys to clients. 
- Keep an optional developer fallback for local API-key usage that remains local to the browser and is never stored in Supabase.

### Description
- Added a Vercel serverless function at `POST /api/ai` (`api/ai.js`) that verifies Supabase bearer tokens, validates payloads, enforces a placeholder per-user daily limit (`20` requests/day), calls DeepSeek's `/chat/completions` with `DEEPSEEK_API_KEY`, and returns frontend-safe JSON errors and results. 
- Implemented a backend proxy integration that reads `AI_PROVIDER`, `DEEPSEEK_API_KEY`, `DEEPSEEK_BASE_URL`, and `DEEPSEEK_MODEL` from environment variables and calls DeepSeek with a 30s timeout and `temperature: 0.4`. 
- Updated the frontend AI client (`src/services/aiClient.ts`) to use VD Cloud AI by default via `callBackendAI(...)` and `requestChatCompletion(...)`, while preserving a local developer API-key mode (stored only in browser `localStorage`) and adding `getAIConnectionLabel(...)` and `isDeveloperAIKeyMode(...)`. 
- Updated AI UI panels (`src/components/AITaskAnalysisPanel.tsx`, `src/components/AIReviewPanel.tsx`, `src/components/AITaskCommandBar.tsx`, `src/components/GoalRoadmapPanel.tsx`) to prefer `/api/ai`, remove normal-user API key gating, and show either `VD Cloud AI 已启用` or `开发者模式：使用本地 API Key`. 
- Added documentation `docs/ai-backend.md` that explains required Vercel env vars, API contract (`POST /api/ai`), local testing with `npx vercel dev`, and the placeholder rate-limit note. 
- Key security choices: the backend `DEEPSEEK_API_KEY` is never sent to the frontend or stored in Supabase, the backend verifies Supabase sessions via `/auth/v1/user`, errors avoid leaking secrets, and the placeholder rate limit is noted as a TODO to move to a durable store.

### Testing
- Ran `npm run build` to compile the frontend and build assets, which completed successfully. 
- Executed `node -e "import('./api/ai.js').then(m=>console.log(typeof m.default))"` to verify the serverless handler module loads and it returned `function`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09518dd644832cab869c0d95722ee3)