### PR TITLE
Fix Supabase email confirmation flow

### DIFF
--- a/src/components/AuthPanel.tsx
+++ b/src/components/AuthPanel.tsx
@@ -17,6 +17,14 @@ export function AuthPanel({ isConfigured, isLoading, error, onSignIn, onSignUp, 
   const [formError, setFormError] = useState<string | undefined>();
   const [isSubmitting, setIsSubmitting] = useState(false);
 
+  function getSubmitErrorMessage(submitError: unknown): string {
+    const message = submitError instanceof Error ? submitError.message : '认证失败，请稍后重试。';
+    if (mode === 'signin' && message.toLowerCase().includes('email not confirmed')) {
+      return '邮箱尚未验证。请打开验证邮件，建议用系统浏览器打开链接。';
+    }
+    return message;
+  }
+
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
     setFormError(undefined);
@@ -27,10 +35,14 @@ export function AuthPanel({ isConfigured, isLoading, error, onSignIn, onSignUp, 
     }
     setIsSubmitting(true);
     try {
-      const session = mode === 'signin' ? await onSignIn(email.trim(), password) : await onSignUp(email.trim(), password);
-      if (!session && mode === 'signup') setStatus('注册成功。请检查邮箱完成验证，然后回到这里登录。');
+      if (mode === 'signin') {
+        await onSignIn(email.trim(), password);
+      } else {
+        await onSignUp(email.trim(), password);
+        setStatus('注册成功，请前往邮箱点击验证链接。验证后再返回登录。');
+      }
     } catch (submitError) {
-      setFormError(submitError instanceof Error ? submitError.message : '认证失败，请稍后重试。');
+      setFormError(getSubmitErrorMessage(submitError));
     } finally {
       setIsSubmitting(false);
     }

--- a/src/hooks/useSupabaseAuth.ts
+++ b/src/hooks/useSupabaseAuth.ts
@@ -1,6 +1,22 @@
 import { useCallback, useEffect, useState } from 'react';
 import { supabase, type SupabaseSession } from '../lib/supabaseClient';
 
+const EMAIL_CONFIRMATION_REDIRECT_URL = 'https://www.visualdeadline.com';
+const AUTH_CALLBACK_QUERY_PARAMS = ['code', 'state', 'error', 'error_code', 'error_description'];
+
+function readAuthCallbackCode(): string | null {
+  if (typeof window === 'undefined') return null;
+  return new URLSearchParams(window.location.search).get('code');
+}
+
+function removeAuthCallbackQueryParams(): void {
+  if (typeof window === 'undefined') return;
+  const url = new URL(window.location.href);
+  AUTH_CALLBACK_QUERY_PARAMS.forEach((param) => url.searchParams.delete(param));
+  const nextUrl = `${url.pathname}${url.search}${url.hash}`;
+  window.history.replaceState(window.history.state, document.title, nextUrl);
+}
+
 export function useSupabaseAuth() {
   const [session, setSession] = useState<SupabaseSession | null>(null);
   const [isLoading, setIsLoading] = useState(true);
@@ -8,7 +24,15 @@ export function useSupabaseAuth() {
 
   useEffect(() => {
     let isMounted = true;
-    supabase.auth.getSession()
+    const callbackCode = readAuthCallbackCode();
+    const sessionPromise = callbackCode
+      ? supabase.auth.exchangeCodeForSession(callbackCode).then((exchangedSession) => {
+        removeAuthCallbackQueryParams();
+        return exchangedSession;
+      })
+      : supabase.auth.getSession();
+
+    sessionPromise
       .then((currentSession) => {
         if (isMounted) setSession(currentSession);
       })
@@ -28,7 +52,11 @@ export function useSupabaseAuth() {
 
   const signUp = useCallback(async (email: string, password: string) => {
     setError(undefined);
-    const nextSession = await supabase.auth.signUp({ email, password });
+    const nextSession = await supabase.auth.signUp({
+      email,
+      password,
+      options: { emailRedirectTo: EMAIL_CONFIRMATION_REDIRECT_URL },
+    });
     if (nextSession) setSession(nextSession);
     return nextSession;
   }, []);

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -33,9 +33,16 @@ interface EmailPasswordCredentials {
   password: string;
 }
 
+interface SignUpCredentials extends EmailPasswordCredentials {
+  options?: {
+    emailRedirectTo?: string;
+  };
+}
+
 const RAW_SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL as string | undefined;
 const RAW_SUPABASE_ANON_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY as string | undefined;
 const SESSION_STORAGE_KEY = 'vd.supabase.session';
+const CODE_VERIFIER_STORAGE_KEY = 'vd.supabase.code_verifier';
 const MISSING_CONFIG_MESSAGE = 'Supabase environment variables are missing.';
 const INVALID_URL_MESSAGE = 'Supabase URL must be a valid project base URL.';
 const SUPABASE_PATH_SUFFIX_PATTERN = /\/(?:rest|auth)\/v1\/?$/i;
@@ -100,6 +107,41 @@ function getRequiredConfig(): SupabaseConfig {
   return supabaseConfigStatus.config;
 }
 
+
+function base64UrlEncode(bytes: Uint8Array): string {
+  let binary = '';
+  bytes.forEach((byte) => {
+    binary += String.fromCharCode(byte);
+  });
+  return window.btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function createCodeVerifier(): string {
+  const randomBytes = new Uint8Array(32);
+  window.crypto.getRandomValues(randomBytes);
+  return base64UrlEncode(randomBytes);
+}
+
+async function createCodeChallenge(codeVerifier: string): Promise<string> {
+  const digest = await window.crypto.subtle.digest('SHA-256', new TextEncoder().encode(codeVerifier));
+  return base64UrlEncode(new Uint8Array(digest));
+}
+
+function storeCodeVerifier(codeVerifier: string): void {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem(CODE_VERIFIER_STORAGE_KEY, codeVerifier);
+}
+
+function readStoredCodeVerifier(): string | null {
+  if (typeof window === 'undefined') return null;
+  return window.localStorage.getItem(CODE_VERIFIER_STORAGE_KEY);
+}
+
+function clearStoredCodeVerifier(): void {
+  if (typeof window === 'undefined') return;
+  window.localStorage.removeItem(CODE_VERIFIER_STORAGE_KEY);
+}
+
 function readStoredSession(): SupabaseSession | null {
   if (typeof window === 'undefined') return null;
   try {
@@ -162,16 +204,41 @@ class VisualDeadlineSupabaseClient {
       }
       return stored;
     },
-    signUp: async ({ email, password }: EmailPasswordCredentials): Promise<SupabaseSession | null> => {
+    signUp: async ({ email, password, options }: SignUpCredentials): Promise<SupabaseSession | null> => {
       const { url, anonKey } = getRequiredConfig();
-      const payload = await parseResponse<{ access_token?: string; refresh_token?: string; expires_in?: number; user: SupabaseUser }>(await fetch(`${url}/auth/v1/signup`, {
+      const signUpUrl = new URL(`${url}/auth/v1/signup`);
+      if (options?.emailRedirectTo) signUpUrl.searchParams.set('redirect_to', options.emailRedirectTo);
+
+      const codeVerifier = createCodeVerifier();
+      const codeChallenge = await createCodeChallenge(codeVerifier);
+      storeCodeVerifier(codeVerifier);
+
+      const payload = await parseResponse<{ access_token?: string; refresh_token?: string; expires_in?: number; user: SupabaseUser }>(await fetch(signUpUrl, {
         method: 'POST',
         headers: { apikey: anonKey, 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email, password }),
+        body: JSON.stringify({ email, password, code_challenge: codeChallenge, code_challenge_method: 's256' }),
       }));
       if (!payload.access_token || !payload.refresh_token) return null;
       const session = toSession(payload as { access_token: string; refresh_token: string; expires_in?: number; user: SupabaseUser });
       persistSession(session);
+      clearStoredCodeVerifier();
+      this.emit(session);
+      return session;
+    },
+    exchangeCodeForSession: async (code: string): Promise<SupabaseSession> => {
+      const { url, anonKey } = getRequiredConfig();
+      const codeVerifier = readStoredCodeVerifier();
+      if (!codeVerifier) {
+        throw new Error('无法完成邮箱验证登录：缺少本机验证凭据。请使用注册时的同一浏览器打开验证链接。');
+      }
+      const payload = await parseResponse<{ access_token: string; refresh_token: string; expires_in?: number; user: SupabaseUser }>(await fetch(`${url}/auth/v1/token?grant_type=pkce`, {
+        method: 'POST',
+        headers: { apikey: anonKey, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ auth_code: code, code_verifier: codeVerifier }),
+      }));
+      const session = toSession(payload);
+      persistSession(session);
+      clearStoredCodeVerifier();
       this.emit(session);
       return session;
     },


### PR DESCRIPTION
### Motivation
- Ensure Supabase email confirmation works reliably by supporting the auth callback PKCE flow and preserving/verifying the PKCE verifier across signup and callback exchange. 
- Avoid automatically signing in right after `signUp` and provide clearer Chinese UX messages for signup success and unconfirmed-email login failures.

### Description
- Add PKCE support and verifier storage to the client: introduced `createCodeVerifier`, `createCodeChallenge`, `store/read/clearStoredCodeVerifier`, and `CODE_VERIFIER_STORAGE_KEY` in `src/lib/supabaseClient.ts` and use them during signup. 
- Extend `signUp` to accept `options.emailRedirectTo` and include `code_challenge`/`code_challenge_method` in the signup request, and added `exchangeCodeForSession(code)` which posts to `auth/v1/token?grant_type=pkce` using the stored `code_verifier` to obtain and persist a session. (File: `src/lib/supabaseClient.ts`)
- Detect and handle Supabase auth callback on app startup: read `code` from `window.location.search`, call `supabase.auth.exchangeCodeForSession(code)` when present, and remove auth query params via `history.replaceState`. Also keep `onAuthStateChange` subscription to update session state. (File: `src/hooks/useSupabaseAuth.ts`)
- Update the auth UI to not auto sign-in after signup and surface clearer messages: show `注册成功，请前往邮箱点击验证链接。验证后再返回登录。` after signup, and translate login failures containing `Email not confirmed` to `邮箱尚未验证。请打开验证邮件，建议用系统浏览器打开链接。` in `src/components/AuthPanel.tsx`.

### Testing
- Ran `npm run build` (which runs `tsc -b && vite build`) and the build completed successfully. 
- Ran `git diff --check` and there were no whitespace/diff errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a095b853abc832c96b1f2fb23deb158)