### PR TITLE
Move long-term goals into Life module

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -903,9 +903,9 @@ function App() {
   );
 
   const moduleContent: Record<LifeOSModule, ReactElement> = {
-    home: <HomePage pressure={pressure} pressureHistory={normalizedPressureHistory} recommendedTasks={recommendedTasks} activeTasks={activeTasks} tasks={normalizedTasks} goals={normalizedGoals} onSaveGoal={saveGoal} onDeleteGoal={deleteGoal} onRoadmapGenerated={(artifact) => { saveAIArtifact(artifact); unlockAchievement('roadmap-generated'); }} onRecalibrate={openRecalibration} onOpenTasks={() => setActiveModule('task')} />,
+    home: <HomePage pressure={pressure} pressureHistory={normalizedPressureHistory} recommendedTasks={recommendedTasks} activeTasks={activeTasks} onRecalibrate={openRecalibration} onOpenTasks={() => setActiveModule('task')} />,
     task: taskModule,
-    map: <LifeMapPage />,
+    map: <LifeMapPage goals={normalizedGoals} tasks={normalizedTasks} onSaveGoal={saveGoal} onDeleteGoal={deleteGoal} onRoadmapGenerated={(artifact) => { saveAIArtifact(artifact); unlockAchievement('roadmap-generated'); }} />,
     social: <SocialPage />,
     log: <LogPage tasks={normalizedTasks} goals={normalizedGoals} profile={normalizedProfile} pressure={pressure} pressureHistory={normalizedPressureHistory} achievements={normalizedAchievements} aiArtifacts={normalizedAIArtifacts} onAIReportGenerated={(artifact) => { saveAIArtifact(artifact); unlockAchievement('ai-report-generated'); }} onDelete={deleteTask} onReviewNoteChange={updateReviewNote} />,
     me: <ProfilePage profile={normalizedProfile} onProfileChange={setProfile} />,

--- a/src/components/GoalRoadmapPanel.tsx
+++ b/src/components/GoalRoadmapPanel.tsx
@@ -16,6 +16,8 @@ interface GoalRoadmapPanelProps {
 
 const categories = ['study', 'research', 'fitness', 'work', 'life', 'social', 'other'] as const;
 
+const roadmapFacets = ['AI 路线图', '阶段拆解', '风险分析', '周期建议'] as const;
+
 type RoadmapState = { loadingGoalId?: string; errorGoalId?: string; message?: string };
 
 function createGoalInput(goal: Goal): GoalInput {
@@ -29,6 +31,10 @@ function createGoalInput(goal: Goal): GoalInput {
   };
 }
 
+function getPreviewItems(goal: Goal) {
+  return goal.roadmapSuggestions?.slice(0, 2) ?? [];
+}
+
 export function GoalRoadmapPanel({ goals, tasks, onSaveGoal, onDeleteGoal, onRoadmapGenerated }: GoalRoadmapPanelProps) {
   const [storedSettings] = useLocalStorage<AISettings>(storageKeys.aiSettings, defaultAISettings);
   const settings = useMemo(() => normalizeAISettings(storedSettings), [storedSettings]);
@@ -37,18 +43,13 @@ export function GoalRoadmapPanel({ goals, tasks, onSaveGoal, onDeleteGoal, onRoa
   const [category, setCategory] = useState<GoalInput['category']>('research');
   const [priority, setPriority] = useState<GoalInput['priority']>(7);
   const [editingGoalId, setEditingGoalId] = useState<string | undefined>();
-  const [selectedGoalId, setSelectedGoalId] = useState<string | undefined>(goals[0]?.id);
+  const [expandedGoalId, setExpandedGoalId] = useState<string | undefined>();
   const [roadmapState, setRoadmapState] = useState<RoadmapState>({});
-  const selectedGoal = goals.find((goal) => goal.id === selectedGoalId) ?? goals[0];
   const isEditing = Boolean(editingGoalId);
 
   useEffect(() => {
-    if (goals.length === 0) {
-      setSelectedGoalId(undefined);
-      return;
-    }
-    if (!selectedGoalId || !goals.some((goal) => goal.id === selectedGoalId)) setSelectedGoalId(goals[0].id);
-  }, [goals, selectedGoalId]);
+    if (expandedGoalId && !goals.some((goal) => goal.id === expandedGoalId)) setExpandedGoalId(undefined);
+  }, [expandedGoalId, goals]);
 
   function resetForm() {
     setTitle('');
@@ -60,7 +61,6 @@ export function GoalRoadmapPanel({ goals, tasks, onSaveGoal, onDeleteGoal, onRoa
 
   function startEditing(goal: Goal) {
     setEditingGoalId(goal.id);
-    setSelectedGoalId(goal.id);
     setTitle(goal.title);
     setTargetDate(goal.targetDate ?? '');
     setCategory(goal.category);
@@ -94,7 +94,7 @@ export function GoalRoadmapPanel({ goals, tasks, onSaveGoal, onDeleteGoal, onRoa
   }
 
   async function generateRoadmap(goal: Goal) {
-    setSelectedGoalId(goal.id);
+    setExpandedGoalId(goal.id);
     setRoadmapState({ loadingGoalId: goal.id });
     try {
       const content = await requestChatCompletion(settings, goalRoadmapSystemPrompt, buildGoalRoadmapUserPrompt(goal, tasks), { mode: 'daily_plan', context: { goals: [goal], tasks } });
@@ -121,85 +121,96 @@ export function GoalRoadmapPanel({ goals, tasks, onSaveGoal, onDeleteGoal, onRoa
   }
 
   return (
-    <section className="rounded-[2.25rem] border border-white/70 bg-white/70 p-6 shadow-xl shadow-slate-200/50 backdrop-blur md:p-8">
+    <section className="rounded-[2.25rem] border border-white/70 bg-white/70 p-5 shadow-xl shadow-slate-200/50 backdrop-blur md:p-7" aria-labelledby="long-term-goals-heading">
       <div className="flex flex-wrap items-start justify-between gap-4">
         <div>
-          <p className="text-sm font-semibold text-slate-500">长期目标</p>
-          <h2 className="mt-1 text-2xl font-semibold text-slate-950">长期目标 / 人生推进</h2>
-          <p className="mt-3 max-w-2xl text-sm leading-6 text-slate-500">把长期方向安静地放进系统：少一点表格感，多一点未来生活规划。</p>
+          <p className="text-sm font-semibold tracking-[0.18em] text-slate-400">LIFE SYSTEM</p>
+          <h2 id="long-term-goals-heading" className="mt-1 text-2xl font-semibold text-slate-950">长期目标 / 人生推进</h2>
+          <p className="mt-2 max-w-xl text-sm leading-6 text-slate-500">战略层只保留方向、阶段与风险；路线图默认收起，避免日常视图变重。</p>
         </div>
-        <span className="rounded-full bg-slate-50 px-3 py-1.5 text-xs font-semibold text-slate-500 ring-1 ring-white/80">{goals.length} 个目标</span>
+        <div className="flex flex-wrap gap-2 text-xs font-semibold text-slate-500">
+          <span className="rounded-full bg-slate-50 px-3 py-1.5 ring-1 ring-white/80">{goals.length} 个目标</span>
+          <span className="rounded-full bg-emerald-50 px-3 py-1.5 text-emerald-700 ring-1 ring-emerald-100">路线图默认折叠</span>
+        </div>
       </div>
 
-      <form onSubmit={submitGoal} className="mt-8 grid gap-4 rounded-[1.75rem] bg-slate-50/55 p-4 ring-1 ring-white/80 lg:grid-cols-[1.1fr_0.7fr_0.65fr_0.85fr_auto] md:p-5">
+      <form onSubmit={submitGoal} className="mt-6 grid gap-3 rounded-[1.5rem] bg-slate-50/70 p-3 ring-1 ring-white/80 md:grid-cols-[1.4fr_0.8fr_0.8fr_1fr_auto]">
         <label className="space-y-2 text-xs font-semibold text-slate-400">
-          未来方向
-          <input value={title} onChange={(event) => setTitle(event.target.value)} placeholder="" className="w-full rounded-2xl border border-transparent bg-white/85 px-4 py-3.5 text-sm text-slate-800 outline-none transition focus:border-sky-100 focus:ring-4 focus:ring-sky-100/60" />
+          目标标题
+          <input value={title} onChange={(event) => setTitle(event.target.value)} placeholder="例如：完成研究方向转型" className="w-full rounded-2xl border border-transparent bg-white/85 px-4 py-3 text-sm text-slate-700 outline-none transition focus:border-sky-100 focus:ring-4 focus:ring-sky-100/60" />
         </label>
         <label className="space-y-2 text-xs font-semibold text-slate-400">
-          时间锚点
-          <input type="text" inputMode="numeric" value={targetDate} onChange={(event) => setTargetDate(event.target.value)} placeholder="" className="w-full rounded-2xl border border-transparent bg-white/85 px-4 py-3.5 text-sm text-slate-800 outline-none transition focus:border-sky-100 focus:ring-4 focus:ring-sky-100/60" />
+          时间跨度
+          <input type="date" value={targetDate} onChange={(event) => setTargetDate(event.target.value)} className="w-full rounded-2xl border border-transparent bg-white/85 px-4 py-3 text-sm text-slate-700 outline-none transition focus:border-sky-100 focus:ring-4 focus:ring-sky-100/60" />
         </label>
         <label className="space-y-2 text-xs font-semibold text-slate-400">
           领域
-          <select value={category} onChange={(event) => setCategory(normalizeActivityType(event.target.value))} className="w-full rounded-2xl border border-transparent bg-white/85 px-4 py-3.5 text-sm text-slate-700 outline-none transition focus:border-sky-100 focus:ring-4 focus:ring-sky-100/60">
+          <select value={category} onChange={(event) => setCategory(normalizeActivityType(event.target.value))} className="w-full rounded-2xl border border-transparent bg-white/85 px-4 py-3 text-sm text-slate-700 outline-none transition focus:border-sky-100 focus:ring-4 focus:ring-sky-100/60">
             {categories.map((item) => <option key={item} value={item}>{getActivityTypeLabel(item)}</option>)}
           </select>
         </label>
-        <label className="space-y-2 rounded-2xl bg-white/75 px-4 py-3 text-xs font-semibold text-slate-400">
+        <label className="space-y-2 rounded-2xl bg-white/75 px-4 py-2.5 text-xs font-semibold text-slate-400">
           重要性 · {priority}/10
           <input type="range" min="1" max="10" value={priority} onChange={(event) => setPriority(clampImportance(Number(event.target.value)))} className="w-full accent-slate-500" />
         </label>
         <div className="flex items-end gap-2">
-          <button type="submit" className="rounded-2xl bg-slate-950 px-5 py-3.5 text-sm font-semibold text-white shadow-sm transition hover:bg-slate-800">{isEditing ? '保存' : '添加'}</button>
-          {isEditing ? <button type="button" onClick={resetForm} className="rounded-2xl px-4 py-3.5 text-sm font-semibold text-slate-500 hover:bg-white/70">取消</button> : null}
+          <button type="submit" className="rounded-2xl bg-slate-950 px-5 py-3 text-sm font-semibold text-white shadow-sm transition hover:bg-slate-800">{isEditing ? '保存' : '创建目标'}</button>
+          {isEditing ? <button type="button" onClick={resetForm} className="rounded-2xl px-4 py-3 text-sm font-semibold text-slate-500 hover:bg-white/70">取消</button> : null}
         </div>
       </form>
 
       {goals.length ? (
-        <div className="mt-7 grid gap-5 lg:grid-cols-[0.85fr_1.15fr]">
-          <div className="space-y-3">
-            {goals.map((goal) => {
-              const isSelected = selectedGoal?.id === goal.id;
-              const isLoading = roadmapState.loadingGoalId === goal.id;
-              return (
-                <article key={goal.id} className={`rounded-2xl border border-white/80 p-4 shadow-sm ring-1 ${isSelected ? 'bg-white/95 ring-slate-200' : 'bg-slate-50/80 ring-white/80'}`}>
-                  <button type="button" onClick={() => setSelectedGoalId(goal.id)} className="block w-full text-left">
-                    <span className="block font-semibold text-slate-950">{goal.title}</span>
-                    <span className="mt-1 block text-xs text-slate-500">{getActivityTypeLabel(goal.category)} · 重要性 {goal.priority}/10{goal.targetDate ? ` · ${goal.targetDate}` : ''}</span>
+        <div className="mt-6 grid gap-3">
+          {goals.map((goal) => {
+            const isExpanded = expandedGoalId === goal.id;
+            const isLoading = roadmapState.loadingGoalId === goal.id;
+            const previewItems = getPreviewItems(goal);
+            return (
+              <article key={goal.id} className="rounded-[1.5rem] border border-white/80 bg-white/80 p-4 shadow-sm ring-1 ring-white/80">
+                <div className="flex flex-wrap items-start justify-between gap-3">
+                  <button type="button" onClick={() => setExpandedGoalId(isExpanded ? undefined : goal.id)} className="min-w-0 flex-1 text-left">
+                    <span className="block text-base font-semibold text-slate-950">{goal.title}</span>
+                    <span className="mt-1 flex flex-wrap gap-2 text-xs font-medium text-slate-500">
+                      <span>{getActivityTypeLabel(goal.category)}</span>
+                      <span>重要性 {goal.priority}/10</span>
+                      <span>{goal.targetDate ? `截至 ${goal.targetDate}` : '长期推进'}</span>
+                    </span>
                   </button>
-                  <div className="mt-3 flex flex-wrap gap-2">
-                    <button type="button" onClick={() => generateRoadmap(goal)} disabled={isLoading} className="rounded-full bg-white/85 px-3 py-1.5 text-xs font-semibold text-slate-600 shadow-sm ring-1 ring-slate-200 hover:bg-slate-50 disabled:cursor-not-allowed disabled:text-slate-300">{goal.roadmapSuggestions?.length ? '重新生成路线图' : isLoading ? '生成中…' : '生成路线图'}</button>
+                  <div className="flex flex-wrap gap-2">
+                    <button type="button" onClick={() => generateRoadmap(goal)} disabled={isLoading} className="rounded-full bg-slate-950 px-3 py-1.5 text-xs font-semibold text-white shadow-sm hover:bg-slate-800 disabled:cursor-not-allowed disabled:bg-slate-200">{goal.roadmapSuggestions?.length ? '重新生成' : isLoading ? '生成中…' : '生成路线图'}</button>
                     <button type="button" onClick={() => startEditing(goal)} className="rounded-full bg-white/85 px-3 py-1.5 text-xs font-semibold text-slate-600 shadow-sm ring-1 ring-slate-200 hover:bg-slate-50">编辑</button>
+                    {goal.roadmapSuggestions?.length ? <button type="button" onClick={() => clearRoadmap(goal)} className="rounded-full bg-white/85 px-3 py-1.5 text-xs font-semibold text-slate-500 shadow-sm ring-1 ring-slate-200 hover:bg-slate-50">清空路线图</button> : null}
                     <button type="button" onClick={() => deleteGoal(goal)} className="rounded-full bg-white/85 px-3 py-1.5 text-xs font-semibold text-rose-500 shadow-sm ring-1 ring-rose-100 hover:bg-rose-50">删除</button>
+                    <button type="button" onClick={() => setExpandedGoalId(isExpanded ? undefined : goal.id)} className="rounded-full px-3 py-1.5 text-xs font-semibold text-slate-500 hover:bg-slate-100">{isExpanded ? '收起' : '展开'}</button>
                   </div>
-                </article>
-              );
-            })}
-          </div>
-          <div className="rounded-3xl bg-slate-50/80 p-4 ring-1 ring-white/80">
-            <div className="flex flex-wrap items-start justify-between gap-3">
-              <div>
-                <h3 className="font-semibold text-slate-950">{selectedGoal?.title ?? '选择一个目标'}</h3>
-                <p className="mt-1 text-xs text-slate-500">路线图包含阶段、里程碑、周/月方向、风险和第一步行动；不会自动创建任务。</p>
-              </div>
-              {selectedGoal ? (
-                <div className="flex flex-wrap gap-2">
-                  <button type="button" onClick={() => generateRoadmap(selectedGoal)} disabled={roadmapState.loadingGoalId === selectedGoal.id} className="rounded-full bg-white px-4 py-2 text-xs font-semibold text-slate-600 shadow-sm ring-1 ring-slate-200 hover:bg-slate-50 disabled:cursor-not-allowed disabled:text-slate-300">{selectedGoal.roadmapSuggestions?.length ? '重新生成路线图' : '生成路线图'}</button>
-                  {selectedGoal.roadmapSuggestions?.length ? <button type="button" onClick={() => clearRoadmap(selectedGoal)} className="rounded-full px-4 py-2 text-xs font-semibold text-slate-500 hover:bg-slate-100">清空路线图</button> : null}
                 </div>
-              ) : null}
-            </div>
-            {selectedGoal && roadmapState.errorGoalId === selectedGoal.id && roadmapState.message ? <p className="mt-3 rounded-2xl bg-rose-50 px-4 py-3 text-sm font-semibold text-rose-600 ring-1 ring-rose-100">{roadmapState.message}</p> : null}
-            {selectedGoal && roadmapState.loadingGoalId === selectedGoal.id ? <p className="mt-3 rounded-2xl bg-sky-50 px-4 py-3 text-sm font-semibold text-sky-700 ring-1 ring-sky-100">正在生成路线图建议……</p> : null}
-            {selectedGoal?.roadmapSuggestions?.length ? (
-              <ol className="mt-4 space-y-2 text-sm text-slate-600">
-                {selectedGoal.roadmapSuggestions.map((item, index) => <li key={`${item}-${index}`} className="rounded-2xl bg-white/80 px-4 py-3 leading-6 ring-1 ring-white/80">{index + 1}. {item}</li>)}
-              </ol>
-            ) : <p className="mt-4 rounded-2xl border border-dashed border-slate-200 p-5 text-sm text-slate-400">尚未生成路线图。点击“生成路线图”后，只会保存结构建议，不会自动创建任务。</p>}
-          </div>
+
+                {roadmapState.errorGoalId === goal.id && roadmapState.message ? <p className="mt-3 rounded-2xl bg-rose-50 px-4 py-3 text-sm font-semibold text-rose-600 ring-1 ring-rose-100">{roadmapState.message}</p> : null}
+                {isLoading ? <p className="mt-3 rounded-2xl bg-sky-50 px-4 py-3 text-sm font-semibold text-sky-700 ring-1 ring-sky-100">正在生成路线图建议……</p> : null}
+
+                {!isExpanded && previewItems.length ? (
+                  <div className="mt-3 flex flex-wrap gap-2">
+                    {previewItems.map((item, index) => <span key={`${item}-${index}`} className="max-w-full truncate rounded-full bg-slate-50 px-3 py-1 text-xs text-slate-500 ring-1 ring-slate-100">{item}</span>)}
+                  </div>
+                ) : null}
+
+                {isExpanded ? (
+                  <div className="mt-4 rounded-[1.25rem] bg-slate-50/80 p-4 ring-1 ring-white/80">
+                    <div className="grid gap-2 md:grid-cols-4">
+                      {roadmapFacets.map((facet) => <div key={facet} className="rounded-2xl bg-white/80 px-3 py-2 text-xs font-semibold text-slate-500 ring-1 ring-white/80">{facet}</div>)}
+                    </div>
+                    {goal.roadmapSuggestions?.length ? (
+                      <ol className="mt-4 space-y-2 text-sm text-slate-600">
+                        {goal.roadmapSuggestions.map((item, index) => <li key={`${item}-${index}`} className="rounded-2xl bg-white/85 px-4 py-3 leading-6 ring-1 ring-white/80"><span className="mr-2 font-semibold text-slate-400">{index + 1}.</span>{item}</li>)}
+                      </ol>
+                    ) : <p className="mt-4 rounded-2xl border border-dashed border-slate-200 p-5 text-sm text-slate-400">尚未生成路线图。生成后将保存阶段拆解、风险与周期建议，但不会自动创建任务。</p>}
+                  </div>
+                ) : null}
+              </article>
+            );
+          })}
         </div>
-      ) : <div className="mt-7 rounded-3xl border border-dashed border-slate-200 p-8 text-center text-sm text-slate-400">添加一个长期目标，开始把任务系统连接到人生推进。</div>}
+      ) : <div className="mt-6 rounded-3xl border border-dashed border-slate-200 p-8 text-center text-sm text-slate-400">添加一个长期目标，开始把任务系统连接到人生推进。</div>}
     </section>
   );
 }

--- a/src/components/HomePage.tsx
+++ b/src/components/HomePage.tsx
@@ -1,7 +1,6 @@
 import { branding } from '../constants/branding';
-import type { AIArtifactInput, Goal, GoalInput, PressureBreakdown, PressureHistoryRecord, Task } from '../types/task';
+import type { PressureBreakdown, PressureHistoryRecord, Task } from '../types/task';
 import { MiniTaskMatrix } from './MiniTaskMatrix';
-import { GoalRoadmapPanel } from './GoalRoadmapPanel';
 import { PressureCard } from './PressureCard';
 import { RecommendationCard } from './RecommendationCard';
 
@@ -10,22 +9,25 @@ interface HomePageProps {
   pressureHistory: PressureHistoryRecord[];
   recommendedTasks: Task[];
   activeTasks: Task[];
-  tasks: Task[];
-  goals: Goal[];
-  onSaveGoal: (input: GoalInput, goalId?: string) => void;
-  onDeleteGoal: (goalId: string) => void;
-  onRoadmapGenerated: (artifact: AIArtifactInput) => void;
   onRecalibrate: () => void;
   onOpenTasks: () => void;
 }
 
-export function HomePage({ pressure, pressureHistory, recommendedTasks, activeTasks, tasks, goals, onSaveGoal, onDeleteGoal, onRoadmapGenerated, onRecalibrate, onOpenTasks }: HomePageProps) {
+export function HomePage({ pressure, pressureHistory, recommendedTasks, activeTasks, onRecalibrate, onOpenTasks }: HomePageProps) {
   return (
     <section className="space-y-7 md:space-y-8">
+      <div className="rounded-[2rem] border border-white/70 bg-white/60 p-5 shadow-xl shadow-slate-200/50 backdrop-blur md:p-6">
+        <div className="flex flex-wrap items-end justify-between gap-3">
+          <div>
+            <p className="text-sm font-semibold tracking-[0.24em] text-slate-400">HOME · EXECUTION LAYER</p>
+            <h1 className="mt-2 text-3xl font-semibold tracking-tight text-slate-950">今日执行中枢</h1>
+          </div>
+          <p className="max-w-md text-sm leading-6 text-slate-500">只保留高频、短周期、可立即行动的信息：任务、优先级、压力与提醒。</p>
+        </div>
+      </div>
       <PressureCard pressure={pressure} history={pressureHistory} onRecalibrate={onRecalibrate} />
       <RecommendationCard tasks={recommendedTasks} pressure={pressure} />
       <MiniTaskMatrix tasks={activeTasks} onOpenTasks={onOpenTasks} />
-      <GoalRoadmapPanel goals={goals} tasks={tasks} onSaveGoal={onSaveGoal} onDeleteGoal={onDeleteGoal} onRoadmapGenerated={onRoadmapGenerated} />
 
       <section className="rounded-[1.5rem] border border-white/60 bg-white/45 px-4 py-3 text-xs text-slate-400 shadow-sm shadow-slate-200/40 backdrop-blur" aria-label="产品品牌信息">
         <div className="flex flex-wrap items-center justify-between gap-2">

--- a/src/components/LifeMapPage.tsx
+++ b/src/components/LifeMapPage.tsx
@@ -1,4 +1,6 @@
 import { useState } from 'react';
+import type { AIArtifactInput, Goal, GoalInput, Task } from '../types/task';
+import { GoalRoadmapPanel } from './GoalRoadmapPanel';
 
 type LifeTreeItem = {
   id: string;
@@ -83,7 +85,26 @@ function LifeNodeCard({ module, focused, onClick }: { module: LifeTreeItem; focu
   );
 }
 
-export function LifeMapPage() {
+interface LifeMapPageProps {
+  goals: Goal[];
+  tasks: Task[];
+  onSaveGoal: (input: GoalInput, goalId?: string) => void;
+  onDeleteGoal: (goalId: string) => void;
+  onRoadmapGenerated?: (artifact: AIArtifactInput) => void;
+}
+
+const lifeSystemSections = [
+  'Life Overview',
+  'Long-Term Goals',
+  'AI Roadmaps',
+  'Life Domains',
+  'Period Planning',
+  'Risk Warnings',
+  'Life Statistics',
+  'Growth Trends',
+];
+
+export function LifeMapPage({ goals, tasks, onSaveGoal, onDeleteGoal, onRoadmapGenerated }: LifeMapPageProps) {
   const [focusedModuleId, setFocusedModuleId] = useState<string | undefined>();
   const focusedModule = lifeModules.find((module) => module.id === focusedModuleId);
 
@@ -97,6 +118,16 @@ export function LifeMapPage() {
         </div>
         {focusedModule ? <button type="button" onClick={() => setFocusedModuleId(undefined)} className="rounded-full bg-white/85 px-5 py-3 text-sm font-semibold text-slate-700 shadow-sm ring-1 ring-slate-200 hover:bg-slate-50">返回人生总览</button> : null}
       </div>
+
+      <div className="grid gap-3 rounded-[2rem] border border-white/70 bg-white/65 p-4 shadow-xl shadow-slate-200/50 backdrop-blur md:grid-cols-4" aria-label="Life module structure">
+        {lifeSystemSections.map((section, index) => (
+          <div key={section} className={`rounded-2xl px-4 py-3 text-sm font-semibold ring-1 ${section === 'Long-Term Goals' ? 'bg-slate-950 text-white ring-slate-900' : 'bg-white/75 text-slate-600 ring-white/80'}`}>
+            <span className="mr-2 text-xs opacity-60">{index + 1}</span>{section}
+          </div>
+        ))}
+      </div>
+
+      <GoalRoadmapPanel goals={goals} tasks={tasks} onSaveGoal={onSaveGoal} onDeleteGoal={onDeleteGoal} onRoadmapGenerated={onRoadmapGenerated} />
 
       <div className="overflow-hidden rounded-[2rem] border border-white/70 bg-white/75 p-5 shadow-xl shadow-slate-200/60 backdrop-blur">
         {!focusedModule ? (


### PR DESCRIPTION
### Motivation
- Separate execution-focused Home view from strategic life planning so the Home page remains lightweight, high-frequency, and action-oriented. 
- Move long-term goal and AI roadmap features into the Life module to concentrate strategic/reflective content in one place without deleting any data structures.

### Description
- Removed long-term goal roadmap UI and related goal props from `HomePage` and simplified the Home props and header to emphasize the execution layer (`src/components/HomePage.tsx`).
- Added a Life System overview and integrated the `GoalRoadmapPanel` into `LifeMapPage`, passing existing goal/task handlers and preserving CRUD and AI roadmap generation flows (`src/components/LifeMapPage.tsx`, `src/components/GoalRoadmapPanel.tsx`).
- Refactored `GoalRoadmapPanel` to be compact by default: added `expandedGoalId`, preview snippets (`getPreviewItems`), roadmap facets, collapsed-by-default UI, and expandable detailed view while keeping create/edit/delete/regenerate/clear behaviors intact (`src/components/GoalRoadmapPanel.tsx`).
- Updated routing so `App.tsx` no longer passes goal/roadmap handlers to Home and instead supplies them to the Life module (`src/App.tsx`).

### Testing
- Ran the production build via `npm run build` (which runs `tsc -b` and `vite build`) and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a096284916c832ca1e8abd56027f418)