### PR TITLE
Add in-app Privacy & Terms pages, require consent on signup, and harden AI auth/header handling

### DIFF
--- a/Protocol/vd_privacy_policy.html
+++ b/Protocol/vd_privacy_policy.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>VD 隐私政策</title>
+  <title>VD（Visual Deadline）隐私政策</title>
 
   <style>
     :root {
@@ -186,11 +186,11 @@
   <div class="container">
 
     <div class="topbar">
-      <div class="logo">VD · Visual Deadline</div>
+      <div class="logo">VD（Visual Deadline）</div>
       <div class="tag">隐私政策</div>
     </div>
 
-    <h1>VD 隐私政策</h1>
+    <h1>VD（Visual Deadline）隐私政策</h1>
 
     <div class="desc">
       更新日期：2026年5月17日<br />
@@ -203,11 +203,11 @@
       </p>
 
       <p>
-        本隐私政策用于说明在你使用 VD 过程中，我们如何收集、使用、存储与保护你的个人信息。
+        本隐私政策用于说明在你使用 VD（Visual Deadline）过程中，我们如何收集、使用、存储与保护你的个人信息。
       </p>
 
       <p>
-        请你在使用本产品前认真阅读本政策。继续使用 VD，即表示你已阅读并理解本隐私政策的内容。
+        请你在使用本产品前认真阅读本政策。继续使用 VD（Visual Deadline），即表示你已阅读并理解本隐私政策的内容。
       </p>
     </div>
 
@@ -216,7 +216,7 @@
     <h3>1. 账号信息</h3>
 
     <p>
-      当你注册或登录 VD 时，我们可能会收集：
+      当你注册或登录 VD（Visual Deadline）时，我们可能会收集：
     </p>
 
     <ul>
@@ -281,7 +281,7 @@
     <h2>三、数据存储与安全</h2>
 
     <p>
-      VD 会尽合理努力保护你的数据安全，包括但不限于：
+      VD（Visual Deadline）会尽合理努力保护你的数据安全，包括但不限于：
     </p>
 
     <ul>
@@ -302,7 +302,7 @@
     <h2>四、Cookie 与本地存储</h2>
 
     <p>
-      为保障登录状态、提升使用体验与优化产品功能，VD 可能会使用：
+      为保障登录状态、提升使用体验与优化产品功能，VD（Visual Deadline）可能会使用：
     </p>
 
     <ul>
@@ -319,7 +319,7 @@
     <h2>五、第三方服务</h2>
 
     <p>
-      VD 当前或未来可能接入第三方服务，包括但不限于：
+      VD（Visual Deadline）当前或未来可能接入第三方服务，包括但不限于：
     </p>
 
     <ul>
@@ -354,7 +354,7 @@
     <h2>七、未成年人保护</h2>
 
     <p>
-      未成年人应在监护人同意与指导下使用 VD。
+      未成年人应在监护人同意与指导下使用 VD（Visual Deadline）。
     </p>
 
     <p>
@@ -374,12 +374,12 @@
     <h2>九、联系我们</h2>
 
     <p>
-      如你对本隐私政策有任何问题，可以通过RanchoTao@gmail.com联系我。
+      如你对本隐私政策有任何问题，可以通过 RanchoTao@gmail.com 联系我们。
     </p>
 
     <div class="footer">
-      VD · Visual Deadline<br />
-      Privacy Policy v1.0
+      VD（Visual Deadline）<br />
+      隐私政策 v1.0
     </div>
 
   </div>

--- a/api/ai.js
+++ b/api/ai.js
@@ -1,6 +1,7 @@
 const MAX_MESSAGE_LENGTH = 12_000;
 const MAX_CONTEXT_LENGTH = 60_000;
 const MAX_REQUESTS_PER_USER_PER_DAY = 20;
+const MAX_AUTH_HEADER_LENGTH = 8_500;
 const DEEPSEEK_PROVIDER = 'deepseek';
 const SUPPORTED_MODES = new Set(['task_advice', 'daily_plan', 'pressure_analysis']);
 const dailyRequestCounts = new Map();
@@ -15,11 +16,34 @@ function readEnv(name, fallbackName) {
   return typeof value === 'string' ? value.trim() : '';
 }
 
-function getBearerToken(request) {
+function getAuthorizationHeader(request) {
   const header = request.headers.authorization || request.headers.Authorization;
-  if (typeof header !== 'string') return '';
-  const match = header.match(/^Bearer\s+(.+)$/i);
+  return typeof header === 'string' ? header : '';
+}
+
+function getBearerToken(request) {
+  const header = getAuthorizationHeader(request);
+  const match = header.match(/^Bearer\s+([^\s]+)$/i);
   return match?.[1]?.trim() || '';
+}
+
+function getApproximateHeaderSize(request) {
+  return Object.entries(request.headers || {}).reduce((total, [key, value]) => {
+    const normalizedValue = Array.isArray(value) ? value.join(',') : String(value ?? '');
+    return total + key.length + normalizedValue.length + 4;
+  }, 0);
+}
+
+function trimForLog(text, maxLength = 2000) {
+  return text.length > maxLength ? `${text.slice(0, maxLength)}…` : text;
+}
+
+function logAIRequestFailure({ url, status, responseText }) {
+  console.error('[VD_API_AI_REQUEST_FAILED]', {
+    url,
+    status,
+    responseText: trimForLog(responseText),
+  });
 }
 
 async function readJsonBody(request) {
@@ -132,6 +156,7 @@ async function callDeepSeek(payload) {
     }
 
     if (!response.ok) {
+      logAIRequestFailure({ url: `${baseUrl.replace(/\/+$/, '')}/chat/completions`, status: response.status, responseText: rawText });
       const upstreamMessage = typeof data?.error?.message === 'string' ? data.error.message : `DeepSeek returned ${response.status}`;
       const error = new Error(upstreamMessage);
       error.status = response.status;
@@ -154,6 +179,13 @@ export default async function handler(request, response) {
   }
 
   try {
+    const headerSize = getApproximateHeaderSize(request);
+    const authorizationHeader = getAuthorizationHeader(request);
+    if (headerSize > 12_000 || authorizationHeader.length > MAX_AUTH_HEADER_LENGTH) {
+      console.error('[VD_API_AI_HEADER_TOO_LARGE]', { headerSize, authorizationHeaderLength: authorizationHeader.length, url: request.url || '/api/ai' });
+      return sendJson(response, 431, { ok: false, error: '请求头过大或登录状态异常。请重新登录；如果仍然失败，请清除本地缓存后再试。' });
+    }
+
     const accessToken = getBearerToken(request);
     if (!accessToken) return sendJson(response, 401, { ok: false, error: '缺少 Supabase 登录凭证。' });
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,9 +7,11 @@ import { LifeOSNav } from './components/LifeOSNav';
 import { LogPage } from './components/LogPage';
 import { OnboardingFlow } from './components/OnboardingFlow';
 import { ProfilePage } from './components/ProfilePage';
+import { PrivacyPolicyPage } from './components/PrivacyPolicyPage';
 import { TaskForm } from './components/TaskForm';
 import { SocialPage } from './components/SocialPage';
 import { TaskPage } from './components/TaskPage';
+import { TermsPlaceholderPage } from './components/TermsPlaceholderPage';
 import { useLocalStorage } from './hooks/useLocalStorage';
 import { useSupabaseAuth } from './hooks/useSupabaseAuth';
 import type { Achievement, AIArtifact, AIArtifactInput, ActivityType, Goal, GoalInput, LifecycleStatus, LifeOSModule, PressureBreakdown, PressureCalibrationSnapshot, PressureHistoryEventType, PressureHistoryRecord, Task, TaskInput, UserProfile } from './types/task';
@@ -342,6 +344,7 @@ function createAchievement(id: string): Achievement | undefined {
 }
 
 function App() {
+  const [publicPath, setPublicPath] = useState(() => window.location.pathname);
   const { session, isLoading: isAuthLoading, error: authError, isConfigured: isSupabaseConfigured, signIn, signUp, signOut } = useSupabaseAuth();
   const [hasChosenGuestMode, setHasChosenGuestMode] = useState(false);
   const [cloudStatus, setCloudStatus] = useState<string | undefined>();
@@ -885,6 +888,21 @@ function App() {
   }
 
 
+
+  useEffect(() => {
+    function syncPublicPath() {
+      setPublicPath(window.location.pathname);
+    }
+
+    window.addEventListener('popstate', syncPublicPath);
+    return () => window.removeEventListener('popstate', syncPublicPath);
+  }, []);
+
+  function navigateHome() {
+    window.history.pushState({}, '', '/');
+    setPublicPath('/');
+  }
+
   const taskModule = (
     <TaskPage
       tasks={normalizedTasks}
@@ -910,6 +928,15 @@ function App() {
     log: <LogPage tasks={normalizedTasks} goals={normalizedGoals} profile={normalizedProfile} pressure={pressure} pressureHistory={normalizedPressureHistory} achievements={normalizedAchievements} aiArtifacts={normalizedAIArtifacts} onAIReportGenerated={(artifact) => { saveAIArtifact(artifact); unlockAchievement('ai-report-generated'); }} onDelete={deleteTask} onReviewNoteChange={updateReviewNote} />,
     me: <ProfilePage profile={normalizedProfile} onProfileChange={setProfile} />,
   };
+
+
+  if (publicPath === '/privacy' || publicPath === '/privacy.html') {
+    return <PrivacyPolicyPage onBack={navigateHome} />;
+  }
+
+  if (publicPath === '/terms') {
+    return <TermsPlaceholderPage onBack={navigateHome} />;
+  }
 
   if (!session && !hasChosenGuestMode) {
     return <AuthPanel isConfigured={isSupabaseConfigured} isLoading={isAuthLoading} error={authError} onSignIn={signIn} onSignUp={signUp} onContinueAsGuest={() => setHasChosenGuestMode(true)} />;

--- a/src/components/AITaskCommandBar.tsx
+++ b/src/components/AITaskCommandBar.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState } from 'react';
 import { useLocalStorage } from '../hooks/useLocalStorage';
 import { storageKeys } from '../storage';
 import type { AIArtifactInput, Task, TaskInput } from '../types/task';
-import { defaultAISettings, getAIConnectionLabel, normalizeAISettings, requestChatCompletion } from '../services/aiClient';
+import { defaultAISettings, getAIConnectionLabel, isCloudAIAuthStateError, normalizeAISettings, requestChatCompletion, resetCloudAIAuthState } from '../services/aiClient';
 import type { AISettings } from '../services/aiClient';
 import { buildTaskIntakeUserPrompt, createTaskIntakePayload, parseTaskIntakeResponse, taskIntakeSystemPrompt } from '../services/taskIntakePrompt';
 import { getActivityTypeLabel } from '../utils/taskScoring';
@@ -31,24 +31,38 @@ export function AITaskCommandBar({ tasks, onConfirmTasks, onAIArtifactGenerated 
   const [notes, setNotes] = useState('');
   const [rawJson, setRawJson] = useState('');
   const [errorMessage, setErrorMessage] = useState('');
+  const [canResetAuthState, setCanResetAuthState] = useState(false);
 
 
   async function structureTasks() {
     const trimmedInput = input.trim();
     if (!trimmedInput) {
       setState('error');
+      setCanResetAuthState(false);
       setErrorMessage('请先输入最近要做的事。');
       return;
     }
 
     setState('loading');
     setErrorMessage('');
+    setCanResetAuthState(false);
     setDrafts([]);
     setNotes('');
     setRawJson('');
     try {
       const payload = createTaskIntakePayload(trimmedInput, tasks);
-      const result = await requestChatCompletion(settings, taskIntakeSystemPrompt, buildTaskIntakeUserPrompt(payload), { mode: 'task_advice', context: { tasks } });
+      const taskContext = tasks
+        .filter((task) => task.lifecycleStatus === 'active')
+        .slice(0, 30)
+        .map((task) => ({
+          id: task.id,
+          title: task.title,
+          deadline: task.deadline,
+          importance: task.importance,
+          progress: task.progress,
+          activityType: task.activityType,
+        }));
+      const result = await requestChatCompletion(settings, taskIntakeSystemPrompt, buildTaskIntakeUserPrompt(payload), { mode: 'task_advice', context: { tasks: taskContext } });
       const parsed = parseTaskIntakeResponse(result);
       setDrafts(parsed.tasks);
       setNotes(parsed.notes);
@@ -65,6 +79,7 @@ export function AITaskCommandBar({ tasks, onConfirmTasks, onAIArtifactGenerated 
       });
     } catch (error) {
       setState('error');
+      setCanResetAuthState(isCloudAIAuthStateError(error));
       setErrorMessage(error instanceof Error ? error.message : '任务整理失败，请稍后重试。');
     }
   }
@@ -76,6 +91,7 @@ export function AITaskCommandBar({ tasks, onConfirmTasks, onAIArtifactGenerated 
     setDrafts([]);
     setNotes('');
     setRawJson('');
+    setCanResetAuthState(false);
     setState('idle');
   }
 
@@ -84,7 +100,14 @@ export function AITaskCommandBar({ tasks, onConfirmTasks, onAIArtifactGenerated 
     setNotes('');
     setRawJson('');
     setErrorMessage('');
+    setCanResetAuthState(false);
     setState('idle');
+  }
+
+  async function resetAuthState() {
+    await resetCloudAIAuthState();
+    setCanResetAuthState(false);
+    setErrorMessage('已清除登录缓存。请重新登录后再使用 VD Cloud AI。');
   }
 
   async function copyJson() {
@@ -115,7 +138,14 @@ export function AITaskCommandBar({ tasks, onConfirmTasks, onAIArtifactGenerated 
         </button>
       </div>
 
-      {state === 'error' && errorMessage ? <div className="mt-4 rounded-2xl bg-rose-50 px-4 py-3 text-sm font-semibold text-rose-600 ring-1 ring-rose-100">{errorMessage}</div> : null}
+      {state === 'error' && errorMessage ? (
+        <div className="mt-4 rounded-2xl bg-rose-50 px-4 py-3 text-sm font-semibold text-rose-600 ring-1 ring-rose-100">
+          <p>{errorMessage}</p>
+          {canResetAuthState ? (
+            <button type="button" onClick={resetAuthState} className="mt-3 rounded-full bg-white px-4 py-2 text-xs font-semibold text-rose-700 ring-1 ring-rose-100 hover:bg-rose-50">重新登录 / 清除登录缓存</button>
+          ) : null}
+        </div>
+      ) : null}
       {state === 'ready' ? (
         <div className="mt-4 rounded-[1.5rem] bg-white/90 p-4 text-slate-900 shadow-inner ring-1 ring-white/80">
           <div className="flex flex-wrap items-center justify-between gap-3">

--- a/src/components/AuthPanel.tsx
+++ b/src/components/AuthPanel.tsx
@@ -16,6 +16,7 @@ export function AuthPanel({ isConfigured, isLoading, error, onSignIn, onSignUp, 
   const [status, setStatus] = useState<string | undefined>();
   const [formError, setFormError] = useState<string | undefined>();
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [hasAcceptedPolicies, setHasAcceptedPolicies] = useState(false);
 
   function getSubmitErrorMessage(submitError: unknown): string {
     const message = submitError instanceof Error ? submitError.message : '认证失败，请稍后重试。';
@@ -31,6 +32,10 @@ export function AuthPanel({ isConfigured, isLoading, error, onSignIn, onSignUp, 
     setStatus(undefined);
     if (!email.trim() || password.length < 6) {
       setFormError('请输入有效邮箱，并使用至少 6 位密码。');
+      return;
+    }
+    if (mode === 'signup' && !hasAcceptedPolicies) {
+      setFormError('请先阅读并同意用户协议与隐私政策');
       return;
     }
     setIsSubmitting(true);
@@ -51,7 +56,7 @@ export function AuthPanel({ isConfigured, isLoading, error, onSignIn, onSignUp, 
   return (
     <main className="min-h-screen bg-[radial-gradient(circle_at_top_left,#dbeafe,transparent_32%),linear-gradient(180deg,#f8fafc,#eef2f7)] px-4 py-10 text-slate-900">
       <section className="mx-auto max-w-xl rounded-[2rem] border border-white/80 bg-white/85 p-7 shadow-2xl shadow-slate-300/60 backdrop-blur">
-        <p className="text-xs font-semibold uppercase tracking-[0.28em] text-slate-400">Visual Deadline Cloud</p>
+        <p className="text-xs font-semibold uppercase tracking-[0.28em] text-slate-400">VD 云同步</p>
         <h1 className="mt-3 text-3xl font-semibold tracking-tight text-slate-950">登录以启用云同步</h1>
         <p className="mt-3 text-sm leading-6 text-slate-500">使用 Supabase 邮箱密码登录后，任务、目标与压力历史会按你的用户 ID 隔离同步。也可以继续使用本机 localStorage。</p>
 
@@ -74,6 +79,22 @@ export function AuthPanel({ isConfigured, isLoading, error, onSignIn, onSignUp, 
           <label className="block text-sm font-semibold text-slate-600">密码
             <input type="password" value={password} onChange={(event) => setPassword(event.target.value)} className="mt-2 w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-slate-900 outline-none focus:border-sky-300" autoComplete={mode === 'signin' ? 'current-password' : 'new-password'} />
           </label>
+          {mode === 'signup' ? (
+            <label className="flex items-start gap-3 rounded-2xl bg-slate-50/85 px-4 py-3 text-sm leading-6 text-slate-600 ring-1 ring-slate-100">
+              <input
+                type="checkbox"
+                checked={hasAcceptedPolicies}
+                onChange={(event) => setHasAcceptedPolicies(event.target.checked)}
+                className="mt-1 h-4 w-4 rounded border-slate-300 text-slate-950 accent-slate-950"
+              />
+              <span>
+                我已阅读并同意
+                <a href="/terms" className="font-semibold text-sky-700 hover:text-sky-900">《用户协议》</a>
+                和
+                <a href="/privacy" className="font-semibold text-sky-700 hover:text-sky-900">《隐私政策》</a>
+              </span>
+            </label>
+          ) : null}
           <button type="submit" disabled={!isConfigured || isLoading || isSubmitting} className="w-full rounded-full bg-slate-950 px-5 py-3 text-sm font-semibold text-white shadow-lg shadow-slate-300 disabled:cursor-not-allowed disabled:bg-slate-300">
             {isSubmitting ? '处理中…' : mode === 'signin' ? '登录并同步' : '注册账号'}
           </button>

--- a/src/components/PrivacyPolicyPage.tsx
+++ b/src/components/PrivacyPolicyPage.tsx
@@ -1,0 +1,128 @@
+interface PrivacyPolicyPageProps {
+  onBack?: () => void;
+}
+
+const sections = [
+  {
+    title: '一、我们收集的信息',
+    blocks: [
+      {
+        heading: '1. 账号信息',
+        content: '当你注册或登录 VD（Visual Deadline）时，我们可能会收集：',
+        items: ['邮箱地址', '用户名', '头像', '账号标识信息'],
+      },
+      {
+        heading: '2. 任务与使用数据',
+        content: '为实现任务管理、统计分析与云同步功能，我们可能会存储：',
+        items: ['任务内容', '截止时间', '重要性数据', '压力指数', '标签与分类', '统计数据', '使用记录'],
+      },
+      {
+        heading: '3. AI 相关数据',
+        content: '当你使用 AI 功能时，我们可能会处理你主动输入的内容，用于任务分析、计划生成、压力评估、效率建议与功能优化。请不要主动输入身份证号、银行卡号、密码等敏感个人信息。',
+      },
+    ],
+  },
+  {
+    title: '二、我们如何使用你的信息',
+    paragraphs: [
+      '我们收集的信息主要用于提供任务管理与云同步服务、优化产品体验、改进 AI 功能质量、保障账号与系统安全，以及进行统计分析与故障排查。',
+      '我们不会出售你的个人数据。',
+    ],
+  },
+  {
+    title: '三、数据存储与安全',
+    paragraphs: [
+      'VD（Visual Deadline）会尽合理努力保护你的数据安全，包括加密传输、访问控制、服务端安全策略与日志审计。',
+      '但你应理解，互联网环境无法保证绝对安全。因网络故障、第三方服务异常、不可抗力或用户自身原因导致的数据风险，我们不承担超出法律规定范围之外的责任。',
+    ],
+  },
+  {
+    title: '四、Cookie 与本地存储',
+    paragraphs: [
+      '为保障登录状态、提升使用体验与优化产品功能，VD（Visual Deadline）可能会使用 Cookie、LocalStorage、SessionStorage 与缓存数据。',
+      '你可以通过浏览器设置清除相关数据。清除后，部分本地数据、登录状态或偏好设置可能无法恢复。',
+    ],
+  },
+  {
+    title: '五、第三方服务',
+    paragraphs: [
+      'VD（Visual Deadline）当前或未来可能接入 Supabase、AI API 服务、云存储服务或数据分析服务。第三方服务可能依据其自身隐私政策处理部分数据。',
+      '我们会尽量只传输实现功能所需的数据，并持续评估第三方服务的数据安全与合规风险。',
+    ],
+  },
+  {
+    title: '六、你的权利',
+    paragraphs: [
+      '你有权查看你的个人数据、修改账号信息、删除部分数据、申请注销账号，或停止使用本产品。部分功能未来可能通过产品内页面逐步开放。',
+    ],
+  },
+  {
+    title: '七、未成年人保护',
+    paragraphs: [
+      '未成年人应在监护人同意与指导下使用 VD（Visual Deadline）。如果监护人发现未成年人未经同意提供个人信息，可联系我们处理。',
+    ],
+  },
+  {
+    title: '八、政策更新',
+    paragraphs: [
+      '我们可能根据产品发展、法律法规变化或运营需要更新本隐私政策。更新后的版本将在本页面中展示。',
+    ],
+  },
+  {
+    title: '九、联系我们',
+    paragraphs: ['如你对本隐私政策有任何问题，可以通过 RanchoTao@gmail.com 联系我们。'],
+  },
+];
+
+export function PrivacyPolicyPage({ onBack }: PrivacyPolicyPageProps) {
+  return (
+    <main className="min-h-screen bg-[radial-gradient(circle_at_top_left,#dbeafe,transparent_32%),radial-gradient(circle_at_top_right,#f8fafc,transparent_30%),linear-gradient(180deg,#f8fafc,#eef2f7)] px-4 py-8 text-slate-900 md:px-8">
+      <article className="mx-auto max-w-4xl rounded-[2rem] border border-white/75 bg-white/82 p-5 shadow-2xl shadow-slate-300/55 backdrop-blur md:p-8">
+        <header className="flex flex-col gap-4 border-b border-slate-100 pb-6 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <p className="text-sm font-semibold uppercase tracking-[0.24em] text-slate-400">VD（Visual Deadline）</p>
+            <h1 className="mt-3 text-3xl font-semibold tracking-tight text-slate-950 md:text-5xl">隐私政策</h1>
+            <p className="mt-4 text-sm leading-6 text-slate-500">更新日期：2026年5月17日 · 生效日期：2026年5月17日</p>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {onBack ? (
+              <button type="button" onClick={onBack} className="rounded-full bg-white/85 px-4 py-2 text-sm font-semibold text-slate-700 shadow-sm ring-1 ring-slate-200 hover:bg-slate-50">返回应用</button>
+            ) : null}
+            <a href="/" className="rounded-full bg-slate-950 px-4 py-2 text-sm font-semibold text-white shadow-sm shadow-slate-300">打开 VD</a>
+          </div>
+        </header>
+
+        <section className="mt-6 rounded-3xl bg-slate-50/85 p-5 text-sm leading-7 text-slate-600 ring-1 ring-white/80 md:p-6">
+          <p>欢迎使用 VD（Visual Deadline）。本隐私政策用于说明在你使用本产品过程中，我们如何收集、使用、存储与保护你的个人信息。</p>
+          <p className="mt-3">请你在使用本产品前认真阅读本政策。继续使用本产品，即表示你已阅读并理解本隐私政策的内容。</p>
+        </section>
+
+        <div className="mt-8 space-y-8">
+          {sections.map((section) => (
+            <section key={section.title} className="scroll-mt-8">
+              <h2 className="text-2xl font-semibold tracking-tight text-slate-950">{section.title}</h2>
+              {section.paragraphs?.map((paragraph) => (
+                <p key={paragraph} className="mt-4 text-base leading-8 text-slate-600">{paragraph}</p>
+              ))}
+              {section.blocks?.map((block) => (
+                <div key={block.heading} className="mt-5 rounded-3xl bg-white/72 p-5 ring-1 ring-slate-100">
+                  <h3 className="text-lg font-semibold text-slate-900">{block.heading}</h3>
+                  <p className="mt-3 text-sm leading-7 text-slate-600">{block.content}</p>
+                  {block.items ? (
+                    <ul className="mt-3 grid gap-2 text-sm text-slate-600 sm:grid-cols-2">
+                      {block.items.map((item) => <li key={item} className="rounded-2xl bg-slate-50 px-3 py-2">{item}</li>)}
+                    </ul>
+                  ) : null}
+                </div>
+              ))}
+            </section>
+          ))}
+        </div>
+
+        <footer className="mt-10 border-t border-slate-100 pt-6 text-sm leading-6 text-slate-500">
+          <p>VD（Visual Deadline）隐私政策 v1.0</p>
+        </footer>
+      </article>
+    </main>
+  );
+}

--- a/src/components/ProfilePage.tsx
+++ b/src/components/ProfilePage.tsx
@@ -19,9 +19,9 @@ const profileFields: { key: keyof UserProfile; label: string; placeholder: strin
 ];
 
 const systemItems = [
-  { title: '本地模式', description: '当前数据保存在本机浏览器；未来云同步会作为可选能力。' },
-  { title: '隐私说明', description: '隐私政策与数据边界预留入口，当前版本不上传个人数据。' },
-  { title: '未来同步', description: '为账号、认证和多设备同步保留结构，但不启用后端。' },
+  { title: '本地模式', description: '未登录时数据保存在本机浏览器；登录后可使用云同步。' },
+  { title: '数据与隐私', description: '查看隐私政策、数据边界与本地存储说明。' },
+  { title: '未来同步', description: '为账号、认证和多设备同步保留结构。' },
 ];
 
 export function ProfilePage({ profile, onProfileChange }: ProfilePageProps) {
@@ -88,6 +88,16 @@ export function ProfilePage({ profile, onProfileChange }: ProfilePageProps) {
               <p className="mt-2 text-xs leading-5 text-slate-500">{item.description}</p>
             </article>
           ))}
+        </div>
+        <div className="mt-4 rounded-3xl bg-white/75 p-4 ring-1 ring-white/80">
+          <p className="text-xs font-semibold uppercase tracking-[0.22em] text-slate-400">设置 / 数据与隐私</p>
+          <div className="mt-3 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <h3 className="text-base font-semibold text-slate-900">隐私政策</h3>
+              <p className="mt-1 text-xs leading-5 text-slate-500">登录后也可以随时查看 VD（Visual Deadline）如何处理与保护你的数据。</p>
+            </div>
+            <a href="/privacy" className="inline-flex items-center justify-center rounded-full bg-slate-950 px-4 py-2 text-sm font-semibold text-white shadow-sm shadow-slate-200">查看隐私政策</a>
+          </div>
         </div>
         <p className="mt-4 rounded-2xl bg-white/75 px-4 py-3 text-xs leading-5 text-slate-500 ring-1 ring-white/80">应用版本 v1.0.1 · 网页优先 · 渐进式应用布局预留</p>
       </section>

--- a/src/components/TermsPlaceholderPage.tsx
+++ b/src/components/TermsPlaceholderPage.tsx
@@ -1,0 +1,19 @@
+interface TermsPlaceholderPageProps {
+  onBack?: () => void;
+}
+
+export function TermsPlaceholderPage({ onBack }: TermsPlaceholderPageProps) {
+  return (
+    <main className="min-h-screen bg-[radial-gradient(circle_at_top_left,#dbeafe,transparent_32%),linear-gradient(180deg,#f8fafc,#eef2f7)] px-4 py-10 text-slate-900">
+      <section className="mx-auto max-w-2xl rounded-[2rem] border border-white/80 bg-white/85 p-7 shadow-2xl shadow-slate-300/60 backdrop-blur">
+        <p className="text-sm font-semibold uppercase tracking-[0.24em] text-slate-400">VD（Visual Deadline）</p>
+        <h1 className="mt-3 text-3xl font-semibold tracking-tight text-slate-950">用户协议页面待补充</h1>
+        <p className="mt-4 text-sm leading-7 text-slate-500">用户协议正在整理中。当前页面用于保留注册协议入口，后续会补充完整条款。</p>
+        <div className="mt-6 flex flex-wrap gap-3">
+          {onBack ? <button type="button" onClick={onBack} className="rounded-full bg-white/85 px-5 py-2.5 text-sm font-semibold text-slate-700 shadow-sm ring-1 ring-slate-200 hover:bg-slate-50">返回应用</button> : null}
+          <a href="/privacy" className="rounded-full bg-slate-950 px-5 py-2.5 text-sm font-semibold text-white shadow-sm shadow-slate-300">查看隐私政策</a>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -43,6 +43,9 @@ const RAW_SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL as string | undefined
 const RAW_SUPABASE_ANON_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY as string | undefined;
 const SESSION_STORAGE_KEY = 'vd.supabase.session';
 const CODE_VERIFIER_STORAGE_KEY = 'vd.supabase.code_verifier';
+const LEGACY_SUPABASE_AUTH_PREFIX = 'sb-';
+const MAX_AUTH_TOKEN_LENGTH = 8_192;
+const JWT_LIKE_PATTERN = /^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/;
 const MISSING_CONFIG_MESSAGE = 'Supabase environment variables are missing.';
 const INVALID_URL_MESSAGE = 'Supabase URL must be a valid project base URL.';
 const SUPABASE_PATH_SUFFIX_PATTERN = /\/(?:rest|auth)\/v1\/?$/i;
@@ -142,29 +145,93 @@ function clearStoredCodeVerifier(): void {
   window.localStorage.removeItem(CODE_VERIFIER_STORAGE_KEY);
 }
 
+function isUsableStoredToken(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0 && value.length <= MAX_AUTH_TOKEN_LENGTH;
+}
+
+function isUsableAccessToken(value: unknown): value is string {
+  return isUsableStoredToken(value) && JWT_LIKE_PATTERN.test(value);
+}
+
+function clearLegacySupabaseStorage(): void {
+  if (typeof window === 'undefined') return;
+
+  const storages = [window.localStorage, window.sessionStorage];
+  storages.forEach((storage) => {
+    for (let index = storage.length - 1; index >= 0; index -= 1) {
+      const key = storage.key(index);
+      if (!key) continue;
+      if (key === SESSION_STORAGE_KEY || key === CODE_VERIFIER_STORAGE_KEY || key.startsWith(LEGACY_SUPABASE_AUTH_PREFIX)) {
+        storage.removeItem(key);
+      }
+    }
+  });
+
+  document.cookie.split(';').forEach((cookie) => {
+    const [rawName] = cookie.split('=');
+    const name = rawName?.trim();
+    if (!name || (!name.startsWith(LEGACY_SUPABASE_AUTH_PREFIX) && !name.startsWith('vd.supabase'))) return;
+    document.cookie = `${name}=; Max-Age=0; path=/; SameSite=Lax`;
+  });
+}
+
+function normalizeStoredSession(value: unknown): SupabaseSession | null {
+  if (!value || typeof value !== 'object') return null;
+  const candidate = value as Record<string, unknown>;
+  if (!isUsableAccessToken(candidate.access_token) || !isUsableStoredToken(candidate.refresh_token)) return null;
+
+  const user = candidate.user && typeof candidate.user === 'object' ? candidate.user as Record<string, unknown> : null;
+  if (!user || typeof user.id !== 'string' || !user.id) return null;
+
+  return {
+    access_token: candidate.access_token,
+    refresh_token: candidate.refresh_token,
+    expires_at: typeof candidate.expires_at === 'number' ? candidate.expires_at : undefined,
+    user: {
+      id: user.id,
+      email: typeof user.email === 'string' ? user.email : undefined,
+    },
+  };
+}
+
 function readStoredSession(): SupabaseSession | null {
   if (typeof window === 'undefined') return null;
   try {
     const raw = window.localStorage.getItem(SESSION_STORAGE_KEY);
-    return raw ? (JSON.parse(raw) as SupabaseSession) : null;
+    if (!raw) return null;
+    const session = normalizeStoredSession(JSON.parse(raw));
+    if (!session) clearLegacySupabaseStorage();
+    return session;
   } catch {
+    clearLegacySupabaseStorage();
     return null;
   }
 }
 
 function persistSession(session: SupabaseSession | null): void {
   if (typeof window === 'undefined') return;
-  if (session) window.localStorage.setItem(SESSION_STORAGE_KEY, JSON.stringify(session));
-  else window.localStorage.removeItem(SESSION_STORAGE_KEY);
+  if (session) {
+    const normalizedSession = normalizeStoredSession(session);
+    if (normalizedSession) window.localStorage.setItem(SESSION_STORAGE_KEY, JSON.stringify(normalizedSession));
+    else clearLegacySupabaseStorage();
+  } else {
+    clearLegacySupabaseStorage();
+  }
 }
 
 function toSession(payload: { access_token: string; refresh_token: string; expires_in?: number; user: SupabaseUser }): SupabaseSession {
-  return {
+  const session = normalizeStoredSession({
     access_token: payload.access_token,
     refresh_token: payload.refresh_token,
     expires_at: payload.expires_in ? Math.floor(Date.now() / 1000) + payload.expires_in : undefined,
     user: payload.user,
-  };
+  });
+  if (!session) throw new Error('Supabase 登录态异常，请重新登录。');
+  return session;
+}
+
+export function clearSupabaseAuthCache(): void {
+  clearLegacySupabaseStorage();
 }
 
 async function parseResponse<T>(response: Response): Promise<T> {
@@ -196,6 +263,10 @@ class VisualDeadlineSupabaseClient {
   }
 
   auth = {
+    clearLocalAuthState: async (): Promise<void> => {
+      persistSession(null);
+      this.emit(null);
+    },
     getSession: async (): Promise<SupabaseSession | null> => {
       const stored = readStoredSession();
       if (!stored) return null;

--- a/src/services/aiClient.ts
+++ b/src/services/aiClient.ts
@@ -39,6 +39,12 @@ export const defaultAISettings: AISettings = {
   model: 'gpt-4o-mini',
 };
 
+const BACKEND_AI_URL = '/api/ai';
+const MAX_SAFE_BEARER_TOKEN_LENGTH = 8_192;
+const JWT_LIKE_PATTERN = /^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/;
+const LARGE_HEADER_STATUS_CODES = new Set([431, 494]);
+const LARGE_HEADER_MESSAGE = 'VD Cloud AI 请求失败：请求头过大或登录状态异常。请重新登录；如果仍然失败，请清除本地缓存后再试。';
+
 export function getProviderDefaults(provider: AIProvider): Pick<AISettings, 'baseUrl' | 'model'> {
   if (provider === 'deepseek-compatible') return { baseUrl: 'https://api.deepseek.com/v1', model: 'deepseek-chat' };
   return { baseUrl: 'https://api.openai.com/v1', model: 'gpt-4o-mini' };
@@ -61,6 +67,14 @@ export function isDeveloperAIKeyMode(settings: Partial<AISettings> | null | unde
 
 export function getAIConnectionLabel(settings: Partial<AISettings> | null | undefined): string {
   return isDeveloperAIKeyMode(settings) ? '开发者模式：使用本地 API Key' : 'VD Cloud AI 已启用';
+}
+
+export function isCloudAIAuthStateError(error: unknown): boolean {
+  return error instanceof Error && /请求头过大|登录状态异常|重新登录|本地缓存/.test(error.message);
+}
+
+export async function resetCloudAIAuthState(): Promise<void> {
+  await supabase.auth.clearLocalAuthState();
 }
 
 interface ChatCompletionChoice {
@@ -88,11 +102,42 @@ function buildBackendMessage(systemPrompt: string, userPrompt: string): string {
   );
 }
 
+function isSafeBearerToken(token: unknown): token is string {
+  return typeof token === 'string' && token.length > 0 && token.length <= MAX_SAFE_BEARER_TOKEN_LENGTH && JWT_LIKE_PATTERN.test(token);
+}
+
+function trimForLog(text: string, maxLength = 2_000): string {
+  return text.length > maxLength ? `${text.slice(0, maxLength)}…` : text;
+}
+
+function logAIRequestFailure(details: { url: string; status: number; responseText: string }): void {
+  console.error('[VD_AI_REQUEST_FAILED]', {
+    url: details.url,
+    status: details.status,
+    responseText: trimForLog(details.responseText),
+  });
+}
+
+function parseJsonResponse<T>(text: string): T | undefined {
+  try {
+    return text ? JSON.parse(text) as T : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function getLargeHeaderMessage(status: number): string | undefined {
+  return LARGE_HEADER_STATUS_CODES.has(status) ? LARGE_HEADER_MESSAGE : undefined;
+}
+
 export async function callBackendAI(request: BackendAIRequest): Promise<BackendAIResponse> {
   const session = await supabase.auth.getSession();
-  if (!session?.access_token) throw new Error('请先登录后再使用 VD Cloud AI。');
+  if (!isSafeBearerToken(session?.access_token)) {
+    await resetCloudAIAuthState();
+    throw new Error(LARGE_HEADER_MESSAGE);
+  }
 
-  const response = await fetch('/api/ai', {
+  const response = await fetch(BACKEND_AI_URL, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -101,15 +146,14 @@ export async function callBackendAI(request: BackendAIRequest): Promise<BackendA
     body: JSON.stringify(request),
   });
 
-  let payload: BackendAIResponse | BackendAIErrorResponse | undefined;
-  try {
-    payload = (await response.json()) as BackendAIResponse | BackendAIErrorResponse;
-  } catch {
-    payload = undefined;
-  }
+  const responseText = await response.text();
+  const payload = parseJsonResponse<BackendAIResponse | BackendAIErrorResponse>(responseText);
 
   if (!response.ok || !payload?.ok) {
-    const message = payload && 'error' in payload && payload.error ? payload.error : `VD Cloud AI 请求失败：${response.status}`;
+    logAIRequestFailure({ url: BACKEND_AI_URL, status: response.status, responseText });
+    const message = getLargeHeaderMessage(response.status)
+      || (payload && 'error' in payload && payload.error ? payload.error : `VD Cloud AI 请求失败：${response.status}`);
+    if (getLargeHeaderMessage(response.status)) await resetCloudAIAuthState();
     throw new Error(message);
   }
 
@@ -139,14 +183,11 @@ async function requestBrowserChatCompletion(settings: AISettings, systemPrompt: 
     }),
   });
 
-  let payload: ChatCompletionResponse | undefined;
-  try {
-    payload = (await response.json()) as ChatCompletionResponse;
-  } catch {
-    payload = undefined;
-  }
+  const responseText = await response.text();
+  const payload = parseJsonResponse<ChatCompletionResponse>(responseText);
 
   if (!response.ok) {
+    logAIRequestFailure({ url: endpoint, status: response.status, responseText });
     const message = payload?.error?.message || (response.status === 401 ? 'API Key 无效或无权限。' : `AI 服务返回错误：${response.status}`);
     throw new Error(message);
   }


### PR DESCRIPTION
### Motivation

- Surface the privacy policy and a placeholder terms page in-app and require consent during signup to meet basic product and compliance expectations.
- Improve robustness of Cloud AI and Supabase auth flows by detecting oversized or malformed auth headers and clearing legacy/invalid auth state to reduce hard-to-debug failures.

### Description

- Add a new `PrivacyPolicyPage` and `TermsPlaceholderPage` and wire routes in `src/App.tsx` to render `/privacy` and `/terms`, including back navigation support via history state.
- Update UI to reference the full product name `VD（Visual Deadline）`, add privacy links in `AuthPanel` and `ProfilePage`, and require a consent checkbox during signup linking to `/terms` and `/privacy` (`src/components/*.tsx`, `Protocol/vd_privacy_policy.html` updates).
- Harden AI backend and client: validate header sizes and bearer tokens, log upstream failures, return a `431` for oversized headers, and attempt to reset cached Cloud AI auth state when necessary (`api/ai.js`, `src/services/aiClient.ts`).
- Limit and sanitize the task context sent to AI from the task intake UI, surface a retry/reset auth action when Cloud AI auth state errors are detected, and capture more informative logs (`src/components/AITaskCommandBar.tsx`, `src/services/aiClient.ts`).
- Normalize and protect Supabase session storage, clear legacy keys/cookies, validate stored session tokens, and expose a local auth-clear API used by the client to reset auth state (`src/lib/supabaseClient.ts`).

### Testing

- Ran TypeScript compilation and a project build (`tsc` / `npm run build`) and the build completed successfully.
- Ran the test suite (`npm test`) and static checks (`eslint`) in CI-like mode and they passed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a096ccfd04c832c936f0a01a9fffc3a)