### PR TITLE
将压力曲线详情迁移到全局 ModalPortal

### DIFF
--- a/src/components/ModalPortal.tsx
+++ b/src/components/ModalPortal.tsx
@@ -15,7 +15,7 @@ export function ModalPortal({ children }: ModalPortalProps) {
   }, []);
 
   return createPortal(
-    <div className="fixed inset-0 z-[9999] flex items-center justify-center bg-slate-950/20 px-4 py-6 backdrop-blur-sm">
+    <div className="fixed inset-0 z-[9999] flex items-center justify-center overflow-hidden bg-slate-950/45 px-4 py-6 backdrop-blur-md">
       {children}
     </div>,
     document.body,

--- a/src/components/PressureCard.tsx
+++ b/src/components/PressureCard.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import type { PressureBreakdown, PressureHistoryRecord } from '../types/task';
 import { PressureTimeline } from './PressureTimeline';
+import { ModalPortal } from './ModalPortal';
 import { isRecentPressureRecord } from '../utils/pressureHistory';
 
 interface PressureCardProps {
@@ -109,12 +110,16 @@ export function PressureCard({ pressure, history, onRecalibrate }: PressureCardP
       </div>
 
       {timelineOpen ? (
-        <div className="fixed inset-0 z-[100] flex items-start justify-center overflow-y-auto bg-slate-950/20 px-4 pb-6 pt-36 backdrop-blur-sm sm:pt-32 md:pt-28 lg:pt-32">
-          <div className="w-full max-w-5xl overflow-y-auto rounded-[2rem] bg-white/95 p-4 shadow-2xl shadow-slate-300/60 max-h-[calc(100dvh-10.5rem)] sm:max-h-[calc(100dvh-9.5rem)] md:max-h-[calc(100dvh-8.5rem)] lg:max-h-[calc(100dvh-9.5rem)]">
-            <div className="mb-3 flex items-center justify-between gap-3 px-2"><h2 className="text-xl font-semibold text-slate-950">压力曲线详情</h2><button type="button" onClick={() => setTimelineOpen(false)} className="rounded-full bg-slate-100 px-4 py-2 text-sm font-semibold text-slate-600 hover:bg-slate-200">关闭</button></div>
-            <PressureTimeline records={history} />
+        <ModalPortal>
+          <div className="max-h-[85vh] w-[min(calc(100vw-2rem),1100px)] overflow-y-auto rounded-[2rem] border border-white/80 bg-white/95 p-5 shadow-2xl shadow-slate-950/25">
+            <div className="sticky top-0 z-10 -mb-10 flex justify-end pointer-events-none">
+              <button type="button" onClick={() => setTimelineOpen(false)} className="pointer-events-auto rounded-full bg-slate-100 px-4 py-2 text-sm font-semibold text-slate-600 shadow-sm hover:bg-slate-200" aria-label="关闭压力曲线详情">关闭</button>
+            </div>
+            <div className="pr-20">
+              <PressureTimeline records={history} variant="modal" />
+            </div>
           </div>
-        </div>
+        </ModalPortal>
       ) : null}
     </section>
   );

--- a/src/components/PressureTimeline.tsx
+++ b/src/components/PressureTimeline.tsx
@@ -3,6 +3,7 @@ import { isBurnoutRiskRecord, isRecentPressureRecord, summarizePressureHistory }
 
 interface PressureTimelineProps {
   records: PressureHistoryRecord[];
+  variant?: 'card' | 'modal';
 }
 
 const eventLabels: Record<NonNullable<PressureHistoryRecord['eventType']>, string> = {
@@ -36,7 +37,7 @@ function pressureToY(pressure: number, chartHeight: number, maxPressure: number)
   return chartHeight - (Math.min(pressure, safeMaxPressure) / safeMaxPressure) * chartHeight;
 }
 
-export function PressureTimeline({ records }: PressureTimelineProps) {
+export function PressureTimeline({ records, variant = 'card' }: PressureTimelineProps) {
   const recentRecords = records.filter((record) => isRecentPressureRecord(record)).slice(-48);
   const stats = summarizePressureHistory(records);
   const chartWidth = 720;
@@ -61,8 +62,10 @@ export function PressureTimeline({ records }: PressureTimelineProps) {
     { label: '近 30 天', active: spanMs <= 30 * 24 * 60 * 60 * 1000 },
   ];
 
+  const shellClassName = variant === 'modal' ? 'p-0' : 'rounded-[2rem] border border-white/70 bg-white/75 p-5 shadow-xl shadow-slate-200/60 backdrop-blur';
+
   return (
-    <section className="rounded-[2rem] border border-white/70 bg-white/75 p-5 shadow-xl shadow-slate-200/60 backdrop-blur">
+    <section className={shellClassName}>
       <div className="flex flex-wrap items-start justify-between gap-4">
         <div>
           <p className="text-sm font-semibold text-slate-500">压力曲线</p>


### PR DESCRIPTION
### Motivation
- 压力曲线详情当前被渲染在页面卡片内，导致内部滚动、被容器遮挡或裁切，需将其升级为真正的全局模态弹窗以避免 stacking context 和 overflow 问题。

### Description
- 把压力详情弹窗从 `PressureCard` 内联浮层改为通过 `ModalPortal` 渲染到 `document.body`，并在 `src/components/PressureCard.tsx` 中使用 `ModalPortal` 包裹弹窗内容。 
- 更新 `ModalPortal`（`src/components/ModalPortal.tsx`）overlay 为 `fixed inset-0 z-[9999]`，加深遮罩、增强模糊并在弹窗打开时锁定 `body` 滚动（恢复逻辑保留）。
- 为详情面板约束尺寸与滚动行为，使弹窗宽度为 `w-[min(calc(100vw-2rem),1100px)]`、最大高度 `max-h-[85vh]`，仅弹窗内部可滚动并把关闭按钮固定/粘性放在右上角（见 `src/components/PressureCard.tsx` 的弹窗模板）。
- 给 `PressureTimeline` 增加 `variant?: 'card' | 'modal'`，在模态场景下移除嵌套卡片外壳以避免“框中框”与双重滚动，同时保留原有图表、时间筛选、事件 marker 与统计逻辑（修改在 `src/components/PressureTimeline.tsx`）。

### Testing
- 运行 `npm run build`（即 `tsc -b && vite build`）构建成功，产物已生成，类型检查与打包通过。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a099d76b594832cb7e5dab348ff9ca0)