### PR TITLE
Fix Vite public asset path regression

### DIFF
--- a/public/logo.svg
+++ b/public/logo.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+<rect width="512" height="512" rx="128" fill="#0f172a"/>
+<circle cx="256" cy="256" r="156" fill="none" stroke="#e0f2fe" stroke-width="34"/>
+<path d="M256 121v135l87 52" fill="none" stroke="#f8fafc" stroke-width="34" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M168 276l53 53 128-146" fill="none" stroke="#38bdf8" stroke-width="36" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/components/LifeOSNav.tsx
+++ b/src/components/LifeOSNav.tsx
@@ -52,7 +52,7 @@ export function LifeOSNav({ activeModule, profile, isSignedIn, isCloudLoading, s
       <div className="flex items-start justify-between gap-4 px-1 py-1 md:items-center md:px-2">
         <button type="button" onClick={() => onModuleChange('home')} className="group flex min-w-0 items-center gap-3 rounded-[1.5rem] px-2 py-1.5 text-left transition duration-300 hover:bg-white/55">
           <span className="flex h-12 w-12 items-center justify-center overflow-hidden rounded-2xl bg-white shadow-lg shadow-slate-300 ring-1 ring-slate-200/70 transition duration-300 group-hover:-translate-y-0.5 group-hover:shadow-xl">
-            <img src="/logo.png" alt="Visual Deadline 标志" className="h-full w-full object-contain" />
+            <img src="/logo.svg" alt="Visual Deadline 标志" className="h-full w-full object-contain" />
           </span>
           <span className="min-w-0">
             <span className="block text-base font-semibold tracking-tight text-slate-950">{branding.productName}</span>


### PR DESCRIPTION
## Problem
Recent Codex-generated PWA changes referenced `/logo.png`, but the repository did not actually contain `public/logo.png`.

Under Vite, only files inside `public/` are guaranteed to exist at runtime when referenced by absolute paths like `/logo.png`.

This caused broken branding assets after deployment.

## Fix
- Added a guaranteed deployable `public/logo.svg`
- Updated `LifeOSNav.tsx` to use `/logo.svg`
- Avoided unnecessary binary file rewrites and manifest churn
- Kept the fix minimal and deployment-safe

## Why this happened
Codex incorrectly assumed root-level binary assets were automatically deployed by Vite.
They are not.

For Vite:
- runtime static assets must live inside `public/`
- or be imported through the module graph

This PR restores a stable deploy path without touching unrelated binary assets.