### PR TITLE
新增移动端布局适配与底部 Tab 导航

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { AuthPanel } from './components/AuthPanel';
 import { HomePage } from './components/HomePage';
 import { LifeMapPage } from './components/LifeMapPage';
 import { LifeOSNav } from './components/LifeOSNav';
+import { MobileBottomNav } from './components/MobileBottomNav';
 import { LogPage } from './components/LogPage';
 import { OnboardingFlow } from './components/OnboardingFlow';
 import { ProfilePage } from './components/ProfilePage';
@@ -954,7 +955,7 @@ function App() {
   }
 
   return (
-    <main className="min-h-screen bg-[radial-gradient(circle_at_top_left,#dbeafe,transparent_32%),radial-gradient(circle_at_top_right,#f8fafc,transparent_30%),linear-gradient(180deg,#f8fafc,#eef2f7)] px-4 py-8 text-slate-900 md:px-8">
+    <main className="min-h-screen overflow-x-hidden bg-[radial-gradient(circle_at_top_left,#dbeafe,transparent_32%),radial-gradient(circle_at_top_right,#f8fafc,transparent_30%),linear-gradient(180deg,#f8fafc,#eef2f7)] px-3 pb-[calc(6rem+env(safe-area-inset-bottom))] pt-3 text-slate-900 md:px-8 md:py-8">
       {!onboardingComplete ? <OnboardingFlow onComplete={completeOnboarding} /> : null}
       {taskFormOverlay}
       {isRecalibrationOpen ? (
@@ -1005,7 +1006,7 @@ function App() {
         </aside>
       ) : null}
 
-      <div className="mx-auto max-w-6xl space-y-5 md:space-y-6">
+      <div className="mx-auto max-w-6xl space-y-4 md:space-y-6">
         <LifeOSNav
           activeModule={activeModule}
           profile={normalizedProfile}
@@ -1019,6 +1020,7 @@ function App() {
         />
         {moduleContent[activeModule]}
       </div>
+      <MobileBottomNav activeModule={activeModule} onModuleChange={setActiveModule} />
     </main>
   );
 }

--- a/src/components/HomePage.tsx
+++ b/src/components/HomePage.tsx
@@ -15,7 +15,7 @@ interface HomePageProps {
 
 export function HomePage({ pressure, pressureHistory, recommendedTasks, activeTasks, onRecalibrate, onOpenTasks }: HomePageProps) {
   return (
-    <section className="space-y-7 md:space-y-8">
+    <section className="space-y-4 md:space-y-8">
       <PressureCard pressure={pressure} history={pressureHistory} onRecalibrate={onRecalibrate} />
       <RecommendationCard tasks={recommendedTasks} pressure={pressure} />
       <MiniTaskMatrix tasks={activeTasks} onOpenTasks={onOpenTasks} />

--- a/src/components/LifeOSNav.tsx
+++ b/src/components/LifeOSNav.tsx
@@ -32,7 +32,7 @@ function getUsername(profile: UserProfile): string {
 }
 
 function Avatar({ profile, size = 'md' }: { profile: UserProfile; size?: 'sm' | 'md' | 'lg' }) {
-  const sizeClass = size === 'lg' ? 'h-16 w-16 text-2xl' : size === 'sm' ? 'h-9 w-9 text-sm' : 'h-11 w-11 text-base';
+  const sizeClass = size === 'lg' ? 'h-16 w-16 text-2xl' : size === 'sm' ? 'h-8 w-8 text-sm md:h-9 md:w-9' : 'h-9 w-9 text-sm md:h-11 md:w-11 md:text-base';
   const initial = getDisplayName(profile).slice(0, 1).toUpperCase();
 
   return (
@@ -47,24 +47,24 @@ export function LifeOSNav({ activeModule, profile, isSignedIn, isCloudLoading, s
   const username = getUsername(profile);
 
   return (
-    <header className="sticky top-3 z-30 overflow-visible rounded-[2rem] border border-white/70 bg-white/78 p-3 shadow-2xl shadow-slate-200/70 backdrop-blur-xl transition-all duration-500 md:top-4" aria-label="Visual Deadline 全局导航">
+    <header className="sticky top-2 z-30 overflow-visible rounded-[1.35rem] border border-white/70 bg-white/78 p-2 shadow-xl shadow-slate-200/60 backdrop-blur-xl transition-all duration-500 md:top-4 md:rounded-[2rem] md:p-3 md:shadow-2xl md:shadow-slate-200/70" aria-label="Visual Deadline 全局导航">
       <div className="pointer-events-none absolute inset-x-8 top-0 h-px bg-gradient-to-r from-transparent via-white to-transparent" />
-      <div className="flex items-start justify-between gap-4 px-1 py-1 md:items-center md:px-2">
-        <button type="button" onClick={() => onModuleChange('home')} className="group flex min-w-0 items-center gap-3 rounded-[1.5rem] px-2 py-1.5 text-left transition duration-300 hover:bg-white/55">
-          <span className="flex h-12 w-12 items-center justify-center overflow-hidden rounded-2xl bg-white shadow-lg shadow-slate-300 ring-1 ring-slate-200/70 transition duration-300 group-hover:-translate-y-0.5 group-hover:shadow-xl">
+      <div className="flex items-center justify-between gap-3 px-0.5 py-0.5 md:gap-4 md:px-2 md:py-1">
+        <button type="button" onClick={() => onModuleChange('home')} className="group flex min-w-0 items-center gap-2 rounded-[1.1rem] px-1.5 py-1 text-left transition duration-300 hover:bg-white/55 md:gap-3 md:rounded-[1.5rem] md:px-2 md:py-1.5">
+          <span className="flex h-9 w-9 items-center justify-center overflow-hidden rounded-xl bg-white shadow-md shadow-slate-300 ring-1 ring-slate-200/70 transition duration-300 group-hover:-translate-y-0.5 group-hover:shadow-xl md:h-12 md:w-12 md:rounded-2xl md:shadow-lg">
             <img src="/logo.png" alt="Visual Deadline 标志" className="h-full w-full object-contain" />
           </span>
           <span className="min-w-0">
-            <span className="block text-base font-semibold tracking-tight text-slate-950">{branding.productName}</span>
+            <span className="block truncate text-sm font-semibold tracking-tight text-slate-950 md:text-base">{branding.productName}</span>
           </span>
         </button>
 
-        <div className="group/avatar relative flex shrink-0 justify-end pb-3 pr-1" onMouseLeave={() => undefined}>
+        <div className="group/avatar relative flex shrink-0 justify-end pr-0.5 md:pb-3 md:pr-1" onMouseLeave={() => undefined}>
           <button type="button" onClick={onOpenProfile} className="rounded-full outline-none transition duration-300 focus-visible:ring-4 focus-visible:ring-sky-100" aria-label="打开个人中心">
             <Avatar profile={profile} />
           </button>
 
-          <div className="pointer-events-none absolute right-0 top-[3.3rem] w-[18rem] translate-y-3 scale-[0.98] opacity-0 transition-all duration-300 ease-out group-hover/avatar:pointer-events-auto group-hover/avatar:translate-y-0 group-hover/avatar:scale-100 group-hover/avatar:opacity-100 group-focus-within/avatar:pointer-events-auto group-focus-within/avatar:translate-y-0 group-focus-within/avatar:scale-100 group-focus-within/avatar:opacity-100">
+          <div className="pointer-events-none absolute right-0 top-11 w-[min(18rem,calc(100vw-1.5rem))] translate-y-3 scale-[0.98] opacity-0 transition-all duration-300 ease-out group-hover/avatar:pointer-events-auto group-hover/avatar:translate-y-0 group-hover/avatar:scale-100 group-hover/avatar:opacity-100 group-focus-within/avatar:pointer-events-auto group-focus-within/avatar:translate-y-0 group-focus-within/avatar:scale-100 group-focus-within/avatar:opacity-100 md:top-[3.3rem] md:w-[18rem]">
             <section className="overflow-hidden rounded-[1.75rem] border border-white/80 bg-white/92 p-4 shadow-2xl shadow-slate-300/70 ring-1 ring-slate-900/5 backdrop-blur-xl">
               <div className="flex items-center gap-3">
                 <Avatar profile={profile} size="lg" />
@@ -108,7 +108,7 @@ export function LifeOSNav({ activeModule, profile, isSignedIn, isCloudLoading, s
         </div>
       </div>
 
-      <nav className="mt-2 rounded-[1.45rem] bg-slate-100/65 p-1" aria-label="Visual Deadline 模块">
+      <nav className="mt-2 hidden rounded-[1.45rem] bg-slate-100/65 p-1 md:block" aria-label="Visual Deadline 模块">
         <div className="grid grid-cols-5 gap-1 sm:flex sm:flex-wrap">
           {navItems.map((item) => {
             const isActive = activeModule === item.id;

--- a/src/components/LogPage.tsx
+++ b/src/components/LogPage.tsx
@@ -120,8 +120,8 @@ export function LogPage({ tasks, goals, profile, pressure, pressureHistory, achi
       <p className="text-sm font-semibold tracking-[0.24em] text-slate-400">数据</p>
       <h1 className="mt-3 text-4xl font-semibold tracking-tight text-slate-950 md:text-5xl">数据</h1>
       <p className="mt-4 max-w-3xl text-sm leading-7 text-slate-500">一个生命状态观测站：追踪你如何工作、如何崩溃、如何恢复、如何演化。VD 不把统计当作后台表格，而把它们当作行为镜像。</p>
-      <div className="mt-6 flex gap-2 overflow-x-auto rounded-[1.5rem] bg-white/60 p-1 ring-1 ring-white/80">
-        {tabs.map((tab) => <button key={tab.id} type="button" onClick={() => setActiveTab(tab.id)} className={`min-w-fit rounded-full px-4 py-2 text-left text-xs font-semibold transition ${activeTab === tab.id ? 'bg-slate-950 text-white shadow-sm' : 'text-slate-500 hover:bg-white/80 hover:text-slate-800'}`}><span className="block">{tab.label}</span><span className="block text-[10px] opacity-70">{tab.description}</span></button>)}
+      <div className="mt-5 flex flex-wrap gap-2 rounded-[1.5rem] bg-white/60 p-1 ring-1 ring-white/80 md:mt-6">
+        {tabs.map((tab) => <button key={tab.id} type="button" onClick={() => setActiveTab(tab.id)} className={`min-h-11 flex-1 rounded-full px-3 py-2 text-left text-xs font-semibold transition sm:flex-none sm:px-4 ${activeTab === tab.id ? 'bg-slate-950 text-white shadow-sm' : 'text-slate-500 hover:bg-white/80 hover:text-slate-800'}`}><span className="block">{tab.label}</span><span className="block text-[10px] opacity-70">{tab.description}</span></button>)}
       </div>
     </header>
 

--- a/src/components/MobileBottomNav.tsx
+++ b/src/components/MobileBottomNav.tsx
@@ -1,0 +1,38 @@
+import type { LifeOSModule } from '../types/task';
+
+interface MobileBottomNavProps {
+  activeModule: LifeOSModule;
+  onModuleChange: (module: LifeOSModule) => void;
+}
+
+const navItems: { id: LifeOSModule; label: string; icon: string }[] = [
+  { id: 'home', label: '首页', icon: '⌂' },
+  { id: 'task', label: '任务', icon: '✓' },
+  { id: 'map', label: '人生', icon: '✦' },
+  { id: 'social', label: '社交', icon: '○' },
+  { id: 'log', label: '数据', icon: '▥' },
+];
+
+export function MobileBottomNav({ activeModule, onModuleChange }: MobileBottomNavProps) {
+  return (
+    <nav className="fixed inset-x-0 bottom-0 z-40 border-t border-white/80 bg-white/90 px-2 pt-2 shadow-[0_-16px_40px_rgba(148,163,184,0.24)] backdrop-blur-xl md:hidden" style={{ paddingBottom: 'env(safe-area-inset-bottom)' }} aria-label="Visual Deadline 移动端模块导航">
+      <div className="mx-auto grid max-w-md grid-cols-5 gap-1 rounded-[1.35rem] bg-slate-100/70 p-1">
+        {navItems.map((item) => {
+          const isActive = activeModule === item.id;
+          return (
+            <button
+              key={item.id}
+              type="button"
+              onClick={() => onModuleChange(item.id)}
+              className={`flex min-h-12 flex-col items-center justify-center rounded-2xl px-2 py-1.5 text-[11px] font-semibold transition-all duration-200 ${isActive ? 'bg-white text-slate-950 shadow-sm shadow-slate-200' : 'text-slate-500 active:bg-white/70'}`}
+              aria-current={isActive ? 'page' : undefined}
+            >
+              <span className="text-base leading-none" aria-hidden="true">{item.icon}</span>
+              <span className="mt-1 leading-none">{item.label}</span>
+            </button>
+          );
+        })}
+      </div>
+    </nav>
+  );
+}

--- a/src/components/PressureCard.tsx
+++ b/src/components/PressureCard.tsx
@@ -69,42 +69,42 @@ export function PressureCard({ pressure, history, onRecalibrate }: PressureCardP
   const path = miniPath(recentHistory);
 
   return (
-    <section className="rounded-[2rem] border border-white/70 bg-white/75 p-5 shadow-xl shadow-slate-200/60 backdrop-blur">
-      <div className="grid gap-5 xl:grid-cols-[1fr_22rem]">
+    <section className="rounded-[1.5rem] border border-white/70 bg-white/75 p-4 shadow-lg shadow-slate-200/50 backdrop-blur md:rounded-[2rem] md:p-5 md:shadow-xl md:shadow-slate-200/60">
+      <div className="grid gap-4 md:gap-5 xl:grid-cols-[1fr_22rem]">
         <div className="min-w-0">
-          <p className="text-sm font-semibold text-slate-500">实时压力指数</p>
-          <div className="mt-2 flex flex-wrap items-end gap-3">
-            <span className="text-5xl font-semibold tracking-tight text-slate-950 tabular-nums transition-colors duration-500">{pressure.state === 'burnout' ? pressure.displayPressure : animatedPressure}</span>
-            <span className={`mb-1 rounded-full px-3 py-1 text-sm font-medium ring-1 ${stateTone[pressure.state]}`}>{pressure.label}</span>
+          <p className="text-xs font-semibold tracking-[0.16em] text-slate-500 md:text-sm md:tracking-normal">实时压力指数</p>
+          <div className="mt-1.5 flex flex-wrap items-end gap-2.5 md:mt-2 md:gap-3">
+            <span className="text-4xl font-semibold tracking-tight text-slate-950 tabular-nums transition-colors duration-500 md:text-5xl">{pressure.state === 'burnout' ? pressure.displayPressure : animatedPressure}</span>
+            <span className={`mb-0.5 rounded-full px-2.5 py-1 text-xs font-medium ring-1 md:mb-1 md:px-3 md:text-sm ${stateTone[pressure.state]}`}>{pressure.label}</span>
           </div>
-          <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-500">{pressure.recommendation}</p>
+          <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-500 md:leading-6">{pressure.recommendation}</p>
 
-          <div className="mt-5 h-2.5 overflow-hidden rounded-full bg-slate-100"><div className={`h-full rounded-full transition-all duration-1000 ease-out ${pressure.state === 'burnout' ? 'bg-rose-300' : 'bg-slate-700'}`} style={{ width: `${meterWidth}%` }} /></div>
-          <div className="mt-4 rounded-3xl bg-slate-50/80 p-4 ring-1 ring-white/80">
-            <p className="text-sm font-semibold text-slate-600">压力 ≈ 当前任务负载 × 个体压力映射系数 - 恢复释放</p>
-            <p className="mt-2 text-xs leading-5 text-slate-500">系统把校准时的主观压力视为当时任务集合的感受，用它映射此刻压力。</p>
-            <div className="mt-3 grid gap-2 text-xs text-slate-500 sm:grid-cols-4">
-              <span className="rounded-full bg-white px-3 py-2">任务负载 {pressure.currentTaskLoad}</span><span className="rounded-full bg-white px-3 py-2">系数 ×{pressure.pressureRatio}</span><span className="rounded-full bg-white px-3 py-2">恢复 -{pressure.recoveryRelief}</span><span className="rounded-full bg-white px-3 py-2">估算 {pressure.rawPressure}</span>
+          <div className="mt-4 h-2 overflow-hidden rounded-full bg-slate-100 md:mt-5 md:h-2.5"><div className={`h-full rounded-full transition-all duration-1000 ease-out ${pressure.state === 'burnout' ? 'bg-rose-300' : 'bg-slate-700'}`} style={{ width: `${meterWidth}%` }} /></div>
+          <div className="mt-3 rounded-2xl bg-slate-50/80 p-3 ring-1 ring-white/80 md:mt-4 md:rounded-3xl md:p-4">
+            <p className="text-xs font-semibold leading-5 text-slate-600 md:text-sm">压力 ≈ 当前任务负载 × 个体压力映射系数 - 恢复释放</p>
+            <p className="mt-1.5 text-xs leading-5 text-slate-500 md:mt-2">系统把校准时的主观压力视为当时任务集合的感受，用它映射此刻压力。</p>
+            <div className="mt-3 grid grid-cols-2 gap-2 text-xs text-slate-500 md:grid-cols-4">
+              <span className="rounded-2xl bg-white px-2.5 py-2 text-center md:rounded-full md:px-3">任务负载 {pressure.currentTaskLoad}</span><span className="rounded-2xl bg-white px-2.5 py-2 text-center md:rounded-full md:px-3">系数 ×{pressure.pressureRatio}</span><span className="rounded-2xl bg-white px-2.5 py-2 text-center md:rounded-full md:px-3">恢复 -{pressure.recoveryRelief}</span><span className="rounded-2xl bg-white px-2.5 py-2 text-center md:rounded-full md:px-3">估算 {pressure.rawPressure}</span>
             </div>
           </div>
         </div>
 
         <aside className="space-y-3">
-          <button type="button" onClick={() => setTimelineOpen(true)} className="w-full rounded-3xl bg-slate-50/80 p-4 text-left ring-1 ring-white/80 transition hover:bg-white">
+          <button type="button" onClick={() => setTimelineOpen(true)} className="w-full rounded-2xl bg-slate-50/80 p-3 text-left ring-1 ring-white/80 transition hover:bg-white md:rounded-3xl md:p-4">
             <div className="flex items-center justify-between gap-3"><p className="text-sm font-semibold text-slate-600">压力曲线</p><span className="text-xs text-slate-400">点击展开</span></div>
-            {recentHistory.length < 2 ? <div className="mt-3 flex h-24 items-center justify-center rounded-2xl bg-white/70 text-xs text-slate-400">继续使用后生成曲线</div> : (
-              <svg viewBox="0 0 220 84" className="mt-3 h-24 w-full overflow-visible" aria-label="迷你压力曲线">
+            {recentHistory.length < 2 ? <div className="mt-3 flex h-20 items-center justify-center rounded-2xl bg-white/70 text-xs text-slate-400 md:h-24">继续使用后生成曲线</div> : (
+              <svg viewBox="0 0 220 84" className="mt-3 h-20 w-full overflow-visible md:h-24" aria-label="迷你压力曲线">
                 <rect x="0" y="0" width="220" height="18" rx="9" fill="#fee2e2" opacity="0.28" />
                 <path d={path} fill="none" stroke="#64748b" strokeLinecap="round" strokeLinejoin="round" strokeWidth="3" />
               </svg>
             )}
           </button>
 
-          <div className="rounded-3xl bg-slate-50/80 p-4 ring-1 ring-white/80">
+          <div className="rounded-2xl bg-slate-50/80 p-3 ring-1 ring-white/80 md:rounded-3xl md:p-4">
             <p className="text-sm font-medium text-slate-600">最近一次校准</p>
-            <p className="mt-2 text-3xl font-semibold text-slate-950">{pressure.referencePressure}</p>
+            <p className="mt-1.5 text-2xl font-semibold text-slate-950 md:mt-2 md:text-3xl">{pressure.referencePressure}</p>
             <div className="mt-3 space-y-2 text-xs text-slate-500"><p>参考任务负载 {pressure.referenceTaskLoad}</p><p>压力映射系数 ×{pressure.pressureRatio}</p></div>
-            <button type="button" onClick={onRecalibrate} className="mt-4 rounded-full bg-white px-4 py-2 text-xs font-semibold text-slate-600 shadow-sm hover:bg-slate-100">重新校准</button>
+            <button type="button" onClick={onRecalibrate} className="mt-4 min-h-10 rounded-full bg-white px-4 py-2 text-xs font-semibold text-slate-600 shadow-sm hover:bg-slate-100">重新校准</button>
           </div>
         </aside>
       </div>

--- a/src/components/PriorityMap.tsx
+++ b/src/components/PriorityMap.tsx
@@ -122,7 +122,7 @@ export function PriorityMap({ tasks }: PriorityMapProps) {
   }, []);
 
   return (
-    <section className="rounded-[2rem] bg-white p-5 shadow-sm ring-1 ring-slate-100">
+    <section className="rounded-[1.5rem] bg-white p-4 shadow-sm ring-1 ring-slate-100 md:rounded-[2rem] md:p-5">
       <div className="mb-4 flex flex-wrap items-end justify-between gap-3">
         <div>
           <p className="text-sm font-semibold text-slate-500">紧急重要矩阵</p>
@@ -134,8 +134,8 @@ export function PriorityMap({ tasks }: PriorityMapProps) {
         </div>
       </div>
 
-      <div className="overflow-x-auto pb-2">
-        <div className="relative mx-auto aspect-square w-full min-w-[34rem] max-w-[44rem] overflow-hidden rounded-[2rem] border border-slate-200 bg-gradient-to-br from-white via-slate-50/80 to-sky-50/40 p-6 shadow-inner">
+      <div className="overflow-hidden pb-2">
+        <div className="relative mx-auto aspect-square w-full max-w-[44rem] overflow-hidden rounded-[1.5rem] border border-slate-200 bg-gradient-to-br from-white via-slate-50/80 to-sky-50/40 p-4 shadow-inner md:min-w-[34rem] md:rounded-[2rem] md:p-6">
           <div className="pointer-events-none absolute inset-x-16 bottom-16 top-16 border border-slate-300/80 bg-[linear-gradient(90deg,rgba(148,163,184,0.08)_1px,transparent_1px),linear-gradient(0deg,rgba(148,163,184,0.08)_1px,transparent_1px)] bg-[size:12.5%_12.5%]" />
           <div className="pointer-events-none absolute bottom-16 left-16 top-16 w-[calc(50%-4rem)] bg-sky-50/35" />
           <div className="pointer-events-none absolute bottom-16 right-16 top-16 w-[calc(50%-4rem)] bg-rose-50/30" />


### PR DESCRIPTION
### Motivation
- 为移动端（屏幕宽度 < 768px）提供专用 UI 布局，保持桌面端原有大卡片 + 顶部胶囊导航不变的同时避免顶部占用过多首屏空间并防止底部导航遮挡内容。

### Description
- 新增 `MobileBottomNav` 组件并在移动端显示固定底部 Tab Bar，支持 `env(safe-area-inset-bottom)` 安全区适配与较大触控区域（文件：`src/components/MobileBottomNav.tsx`）。
- 将 App 外层容器在移动端改为更紧凑的顶/底间距，增加底部 padding 以避开底部导航并加入 `overflow-x-hidden` 防止横向滚动（文件：`src/App.tsx`）。
- Header（`LifeOSNav`）在移动端显著缩小高度、padding、Logo/标题/头像尺寸并隐藏桌面胶囊导航到 `md` 断点以保留桌面体验（文件：`src/components/LifeOSNav.tsx`）。
- 针对移动端对首页压力卡片、任务矩阵、数据页标签等做样式收敛：减小 padding、圆角、字号与间距、去除移动端依赖的横向滚动，同时保留桌面端样式在 `md` 及以上不变（文件：`src/components/PressureCard.tsx`、`src/components/HomePage.tsx`、`src/components/PriorityMap.tsx`、`src/components/LogPage.tsx`）。

### Testing
- 成功执行 `npm run build` 并生成静态构建包（Vite 构建通过）。
- 使用 `curl -I http://127.0.0.1:5173/` 返回 `200 OK`，表示本地开发服务器可正常响应页面。 
- 运行 `git diff --check` 与代码静态检查通过且变更已编译通过。 
- 尝试自动化浏览器工具 `npx playwright --version` 以做视口截图验证时受限于环境（npm registry 返回 403），因此无法在当前环境自动化截图验证 iPhone 390px / Android 412px / Desktop 1440px，但已通过 Tailwind 响应式断点与本地构建验证布局路径。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a944c5930832c9d065b04adcf4ba7)