### PR TITLE
Fix favicon & PWA icon metadata and add cache-busting for favicons

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,9 +4,10 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="theme-color" content="#f8fafc" />
-    <link rel="icon" href="/favicon.ico" />
-    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
-    <link rel="manifest" href="/site.webmanifest" />
+    <link rel="icon" type="image/png" href="/favicon.png?v=2" />
+    <link rel="shortcut icon" href="/favicon.ico?v=2" />
+    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png?v=2" />
+    <link rel="manifest" href="/site.webmanifest?v=2" />
     <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-title" content="Visual Deadline" />

--- a/public/favicon.png
+++ b/public/favicon.png
@@ -1,0 +1,1 @@
+../favicon-96x96.png

--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -1,17 +1,24 @@
 {
   "name": "Visual Deadline",
   "short_name": "VD",
-  "start_url": "/",
+  "description": "Visual Deadline · 可视：人生操作系统",
+  "start_url": "/?source=pwa",
   "scope": "/",
   "display": "standalone",
   "background_color": "#f8fafc",
   "theme_color": "#f8fafc",
   "icons": [
     {
-      "src": "/logo.png",
-      "sizes": "500x500",
+      "src": "/web-app-manifest-192x192.png?v=2",
+      "sizes": "192x192",
       "type": "image/png",
-      "purpose": "any"
+      "purpose": "any maskable"
+    },
+    {
+      "src": "/web-app-manifest-512x512.png?v=2",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "any maskable"
     }
   ]
 }

--- a/public/web-app-manifest-192x192.png
+++ b/public/web-app-manifest-192x192.png
@@ -1,0 +1,1 @@
+../web-app-manifest-192x192.png

--- a/public/web-app-manifest-512x512.png
+++ b/public/web-app-manifest-512x512.png
@@ -1,0 +1,1 @@
+../web-app-manifest-512x512.png

--- a/site.webmanifest
+++ b/site.webmanifest
@@ -1,21 +1,24 @@
 {
-  "name": "MyWebSite",
-  "short_name": "MySite",
+  "name": "Visual Deadline",
+  "short_name": "VD",
+  "description": "Visual Deadline · 可视：人生操作系统",
+  "start_url": "/?source=pwa",
+  "scope": "/",
+  "display": "standalone",
+  "background_color": "#f8fafc",
+  "theme_color": "#f8fafc",
   "icons": [
     {
-      "src": "/web-app-manifest-192x192.png",
+      "src": "/web-app-manifest-192x192.png?v=2",
       "sizes": "192x192",
       "type": "image/png",
-      "purpose": "maskable"
+      "purpose": "any maskable"
     },
     {
-      "src": "/web-app-manifest-512x512.png",
+      "src": "/web-app-manifest-512x512.png?v=2",
       "sizes": "512x512",
       "type": "image/png",
-      "purpose": "maskable"
+      "purpose": "any maskable"
     }
-  ],
-  "theme_color": "#ffffff",
-  "background_color": "#ffffff",
-  "display": "standalone"
+  ]
 }

--- a/src/utils/pwaAssets.ts
+++ b/src/utils/pwaAssets.ts
@@ -1,8 +1,10 @@
 const APP_NAME = 'Visual Deadline';
 const THEME_COLOR = '#f8fafc';
-const FAVICON_PATH = '/favicon.ico';
-const APPLE_TOUCH_ICON_PATH = '/apple-touch-icon.png';
-const MANIFEST_PATH = '/site.webmanifest';
+const ASSET_VERSION = 'v=2';
+const FAVICON_PNG_PATH = `/favicon.png?${ASSET_VERSION}`;
+const FAVICON_ICO_PATH = `/favicon.ico?${ASSET_VERSION}`;
+const APPLE_TOUCH_ICON_PATH = `/apple-touch-icon.png?${ASSET_VERSION}`;
+const MANIFEST_PATH = `/site.webmanifest?${ASSET_VERSION}`;
 
 function upsertMeta(name: string, content: string): void {
   let meta = document.head.querySelector<HTMLMetaElement>(`meta[name="${name}"]`);
@@ -31,9 +33,10 @@ export function configurePwaAssets(): void {
   upsertMeta('apple-mobile-web-app-capable', 'yes');
   upsertMeta('apple-mobile-web-app-title', APP_NAME);
   upsertMeta('apple-mobile-web-app-status-bar-style', 'default');
-  // Flat public root assets: favicon for browser tabs, Apple icon for iOS, manifest for Android/PWA.
-  upsertLink('icon', FAVICON_PATH, { type: 'image/x-icon' });
-  upsertLink('shortcut icon', FAVICON_PATH, { type: 'image/x-icon' });
+  // Flat public root assets: PNG favicon for modern browser tabs, ICO fallback for legacy tabs,
+  // Apple icon for iOS, and a versioned manifest for Android/PWA install surfaces.
+  upsertLink('icon', FAVICON_PNG_PATH, { type: 'image/png' });
+  upsertLink('shortcut icon', FAVICON_ICO_PATH);
   upsertLink('apple-touch-icon', APPLE_TOUCH_ICON_PATH, { sizes: '180x180' });
   upsertLink('manifest', MANIFEST_PATH);
 }


### PR DESCRIPTION
### Motivation
- The browser tab (favicon) was not reliably showing the Visual Deadline logo and PWA icons were not consistently defined for Android/iOS and install surfaces. 
- Browsers aggressively cache favicons which can prevent updates from appearing in the tab bar. 
- Ensure runtime head injection and static HTML head are consistent while avoiding changes to binary image files.

### Description
- Updated static head in `index.html` to use a modern PNG favicon with a cache-busting query (`/favicon.png?v=2`) and keep `/favicon.ico?v=2` as a fallback, added versioned `apple-touch-icon` and `manifest` links. 
- Synchronized runtime injection in `src/utils/pwaAssets.ts` to use a single `ASSET_VERSION` and the same versioned paths for `icon`, `shortcut icon`, `apple-touch-icon`, and `manifest`. 
- Replaced old manifest content with proper app metadata and added versioned PWA icons (`192x192` and `512x512`) declared as `any maskable` in `public/site.webmanifest` and the root `site.webmanifest`. 
- Added lightweight `public/` symlinks to point to existing checked-in PNG assets (`favicon-96x96.png`, `web-app-manifest-192x192.png`, `web-app-manifest-512x512.png`) to avoid modifying binary files while ensuring the assets appear in the public build output. 

### Testing
- Ran `npm run build` and the build completed successfully. 
- Executed a Python validation script that verified image dimensions for `public/favicon.png` (96x96), `public/apple-touch-icon.png` (180x180), PWA icons (192x192 and 512x512), and the `favicon.ico` multi-size entries, and validated manifest `icons` entries. 
- Launched `npm run preview -- --host 127.0.0.1` and performed `curl -sSI` checks which returned `200 OK` for `/favicon.png?v=2`, `/favicon.ico?v=2`, `/apple-touch-icon.png?v=2`, `/site.webmanifest?v=2`, `/web-app-manifest-192x192.png?v=2`, and `/web-app-manifest-512x512.png?v=2` and observed `Cache-Control: no-cache` headers. 
- Automated browser UI verification was not run because Chrome/Edge/Playwright are not available in the environment, so visual checks on actual devices/browsers should be performed after deployment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a98da6f5c832cb77ea3f80172c38e)