### PR TITLE
Update homepage footer branding

### DIFF
--- a/src/components/HomePage.tsx
+++ b/src/components/HomePage.tsx
@@ -1,4 +1,4 @@
-import { branding } from '../constants/branding';
+import { branding, footerBranding } from '../constants/branding';
 import type { PressureBreakdown, PressureHistoryRecord, Task } from '../types/task';
 import { MiniTaskMatrix } from './MiniTaskMatrix';
 import { PressureCard } from './PressureCard';
@@ -21,9 +21,22 @@ export function HomePage({ pressure, pressureHistory, recommendedTasks, activeTa
       <MiniTaskMatrix tasks={activeTasks} onOpenTasks={onOpenTasks} />
 
       <section className="rounded-[1.5rem] border border-white/60 bg-white/45 px-4 py-3 text-xs text-slate-400 shadow-sm shadow-slate-200/40 backdrop-blur" aria-label="产品品牌信息">
-        <div className="flex flex-wrap items-center justify-between gap-2">
-          <p className="font-medium text-slate-500">{branding.organizationName} · {branding.productName} v{branding.version} · 作者 {branding.author}</p>
-          <a href={branding.githubUrl} target="_blank" rel="noreferrer" className="font-semibold text-slate-500 underline-offset-4 hover:text-slate-700 hover:underline">源码</a>
+        <div className="flex min-h-8 flex-col justify-center gap-3 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
+          <p className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1 font-medium leading-5 text-slate-500">
+            <span className="whitespace-nowrap">{footerBranding.brandName}</span>
+            <span aria-hidden="true" className="text-slate-300">·</span>
+            <span className="whitespace-nowrap">{footerBranding.productVersion}</span>
+            <span aria-hidden="true" className="text-slate-300">·</span>
+            <span className="whitespace-nowrap">{footerBranding.authorCredit}</span>
+          </p>
+          <a
+            href={branding.githubUrl}
+            target="_blank"
+            rel="noreferrer"
+            className="inline-flex min-h-8 shrink-0 items-center justify-center self-start rounded-full px-3 py-1.5 font-semibold leading-none text-slate-500 underline-offset-4 transition-colors duration-200 hover:bg-white/60 hover:text-slate-700 hover:underline sm:self-center"
+          >
+            {footerBranding.githubLabel}
+          </a>
         </div>
       </section>
     </section>

--- a/src/constants/branding.ts
+++ b/src/constants/branding.ts
@@ -1,9 +1,17 @@
 export const branding = {
-  organizationName: 'Flysoon Labs',
+  organizationName: 'Flysoon Tech 飞升科技',
   productName: 'Visual Deadline',
   tagline: '可视：人生操作系统',
-  version: '1.0.1',
-  author: 'RanchoTao',
+  version: '2.0.0',
+  author: 'Rancho Tao',
   githubRepo: 'RanchoTao/Visualized-Deadline',
   githubUrl: 'https://github.com/RanchoTao/Visualized-Deadline',
+  githubButtonLabel: 'GitHub',
+} as const;
+
+export const footerBranding = {
+  brandName: branding.organizationName,
+  productVersion: `${branding.productName} v${branding.version}`,
+  authorCredit: `By ${branding.author}`,
+  githubLabel: branding.githubButtonLabel,
 } as const;


### PR DESCRIPTION
### Motivation
- Update the footer copy to a more modern, formal and international presentation and make the version configurable for future updates.
- Keep the existing rounded, frosted/light-gray visual style while improving alignment, spacing and mobile wrapping to avoid overflow.
- Make the footer text and button more touch-friendly and easier to maintain by extracting footer-specific labels into constants.

### Description
- Replaced hard-coded values and updated branding in `src/constants/branding.ts`: `organizationName` → `Flysoon Tech 飞升科技`, `version` → `2.0.0`, and `author` → `Rancho Tao`, and added `githubButtonLabel` and a new `footerBranding` config object for footer-specific labels.
- Refactored `src/components/HomePage.tsx` to read footer text from `footerBranding`, use `whitespace-nowrap` for brand/version/author segments, and rearranged the container to vertically center content and provide balanced left/right spacing with responsive wrapping.
- Replaced the old `源码` link with a lightweight rounded `GitHub` button that preserves the existing hover animation while increasing the click/touch area via `inline-flex`, `min-h-8`, and larger padding.
- Ensured mobile adaptability by using a flexible column→row layout (`flex-col` on small screens, `sm:flex-row`) and `min-w-0`/`flex-wrap` to prevent text overflow and abnormal spacing between Chinese and English text.

### Testing
- Ran `npm run build` successfully and verified the app built without errors.
- Started the dev server with `npm run dev -- --host 127.0.0.1` for a visual check attempt and the server started; a screenshot attempt using Playwright failed because Playwright is not installed in the environment.
- All automated build steps completed successfully and the modified files compile as part of the project build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ab6c18f74832c882a716a4fb5af43)