### PR TITLE
Improve Supabase auth flow: callback handling, resend verification, status messages and footer branding

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -348,7 +348,7 @@ function createAchievement(id: string): Achievement | undefined {
 
 function App() {
   const [publicPath, setPublicPath] = useState(() => window.location.pathname);
-  const { session, isLoading: isAuthLoading, error: authError, isConfigured: isSupabaseConfigured, signIn, signUp, signOut } = useSupabaseAuth();
+  const { session, isLoading: isAuthLoading, error: authError, status: authStatus, isConfigured: isSupabaseConfigured, signIn, signUp, resendVerificationEmail, signOut } = useSupabaseAuth();
   const [hasChosenGuestMode, setHasChosenGuestMode] = useState(false);
   const [cloudStatus, setCloudStatus] = useState<string | undefined>();
   const [cloudToast, setCloudToast] = useState<string | undefined>();
@@ -951,7 +951,7 @@ function App() {
   }
 
   if (!session && !hasChosenGuestMode) {
-    return <AuthPanel isConfigured={isSupabaseConfigured} isLoading={isAuthLoading} error={authError} onSignIn={signIn} onSignUp={async (email, password, identity) => { setProfile({ ...normalizedProfile, ...identity }); return signUp(email, password, identity); }} onContinueAsGuest={() => setHasChosenGuestMode(true)} />;
+    return <AuthPanel isConfigured={isSupabaseConfigured} isLoading={isAuthLoading} error={authError} status={authStatus} onSignIn={signIn} onSignUp={async (email, password, identity) => { setProfile({ ...normalizedProfile, ...identity }); return signUp(email, password, identity); }} onResendVerification={resendVerificationEmail} onContinueAsGuest={() => setHasChosenGuestMode(true)} />;
   }
 
   return (

--- a/src/components/AuthPanel.tsx
+++ b/src/components/AuthPanel.tsx
@@ -1,4 +1,5 @@
-import { useState, type ChangeEvent, type FormEvent } from 'react';
+import { useEffect, useState, type ChangeEvent, type FormEvent } from 'react';
+import { EMAIL_NOT_CONFIRMED_MESSAGE, EMAIL_VERIFICATION_SENT_MESSAGE } from '../constants/authMessages';
 import type { UserProfile } from '../types/task';
 
 type SignupIdentity = Pick<UserProfile, 'avatarDataUrl' | 'nickname' | 'username'>;
@@ -7,27 +8,33 @@ interface AuthPanelProps {
   isConfigured: boolean;
   isLoading: boolean;
   error?: string;
+  status?: string;
   onSignIn: (email: string, password: string) => Promise<unknown>;
   onSignUp: (email: string, password: string, identity: SignupIdentity) => Promise<unknown>;
+  onResendVerification: (email: string) => Promise<unknown>;
   onContinueAsGuest: () => void;
 }
 
-export function AuthPanel({ isConfigured, isLoading, error, onSignIn, onSignUp, onContinueAsGuest }: AuthPanelProps) {
+export function AuthPanel({ isConfigured, isLoading, error, status: authStatus, onSignIn, onSignUp, onResendVerification, onContinueAsGuest }: AuthPanelProps) {
   const [mode, setMode] = useState<'signin' | 'signup'>('signin');
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [nickname, setNickname] = useState('');
   const [username, setUsername] = useState('');
   const [avatarDataUrl, setAvatarDataUrl] = useState<string | undefined>();
-  const [status, setStatus] = useState<string | undefined>();
+  const [status, setStatus] = useState<string | undefined>(authStatus);
   const [formError, setFormError] = useState<string | undefined>();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [hasAcceptedPolicies, setHasAcceptedPolicies] = useState(false);
 
+  useEffect(() => {
+    setStatus(authStatus);
+  }, [authStatus]);
+
   function getSubmitErrorMessage(submitError: unknown): string {
     const message = submitError instanceof Error ? submitError.message : '认证失败，请稍后重试。';
     if (mode === 'signin' && message.toLowerCase().includes('email not confirmed')) {
-      return '邮箱尚未验证。请打开验证邮件，建议用系统浏览器打开链接。';
+      return EMAIL_NOT_CONFIRMED_MESSAGE;
     }
     return message;
   }
@@ -62,10 +69,31 @@ export function AuthPanel({ isConfigured, isLoading, error, onSignIn, onSignUp, 
         await onSignIn(email.trim(), password);
       } else {
         await onSignUp(email.trim(), password, { avatarDataUrl, nickname: nickname.trim(), username: cleanUsername });
-        setStatus('注册成功，请前往邮箱点击验证链接。验证后再返回登录。你的 VD 身份资料已保存。');
+        setStatus(EMAIL_VERIFICATION_SENT_MESSAGE);
       }
     } catch (submitError) {
       setFormError(getSubmitErrorMessage(submitError));
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+
+  async function handleResendVerification() {
+    setFormError(undefined);
+    setStatus(undefined);
+    const cleanEmail = email.trim();
+    if (!cleanEmail) {
+      setFormError('请输入邮箱后再重新发送验证邮件。');
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      await onResendVerification(cleanEmail);
+      setStatus(EMAIL_VERIFICATION_SENT_MESSAGE);
+    } catch (resendError) {
+      setFormError(resendError instanceof Error ? resendError.message : '重新发送验证邮件失败，请稍后重试。');
     } finally {
       setIsSubmitting(false);
     }
@@ -120,6 +148,18 @@ export function AuthPanel({ isConfigured, isLoading, error, onSignIn, onSignUp, 
           <label className="block text-sm font-semibold text-slate-600">密码
             <input type="password" value={password} onChange={(event) => setPassword(event.target.value)} className="mt-2 w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-slate-900 outline-none transition focus:border-sky-300 focus:ring-4 focus:ring-sky-100/70" autoComplete={mode === 'signin' ? 'current-password' : 'new-password'} />
           </label>
+          {mode === 'signin' ? (
+            <div className="flex justify-end">
+              <button
+                type="button"
+                onClick={handleResendVerification}
+                disabled={!isConfigured || isLoading || isSubmitting}
+                className="text-xs font-semibold text-slate-500 underline-offset-4 transition hover:text-slate-800 hover:underline disabled:cursor-not-allowed disabled:text-slate-300"
+              >
+                重新发送验证邮件
+              </button>
+            </div>
+          ) : null}
           {mode === 'signup' ? (
             <label className="flex items-start gap-3 rounded-2xl bg-slate-50/85 px-4 py-3 text-sm leading-6 text-slate-600 ring-1 ring-slate-100">
               <input

--- a/src/components/HomePage.tsx
+++ b/src/components/HomePage.tsx
@@ -1,4 +1,4 @@
-import { branding } from '../constants/branding';
+import { branding, footerBranding } from '../constants/branding';
 import type { PressureBreakdown, PressureHistoryRecord, Task } from '../types/task';
 import { MiniTaskMatrix } from './MiniTaskMatrix';
 import { PressureCard } from './PressureCard';
@@ -21,9 +21,22 @@ export function HomePage({ pressure, pressureHistory, recommendedTasks, activeTa
       <MiniTaskMatrix tasks={activeTasks} onOpenTasks={onOpenTasks} />
 
       <section className="rounded-[1.5rem] border border-white/60 bg-white/45 px-4 py-3 text-xs text-slate-400 shadow-sm shadow-slate-200/40 backdrop-blur" aria-label="产品品牌信息">
-        <div className="flex flex-wrap items-center justify-between gap-2">
-          <p className="font-medium text-slate-500">{branding.organizationName} · {branding.productName} v{branding.version} · 作者 {branding.author}</p>
-          <a href={branding.githubUrl} target="_blank" rel="noreferrer" className="font-semibold text-slate-500 underline-offset-4 hover:text-slate-700 hover:underline">源码</a>
+        <div className="flex min-h-8 flex-col justify-center gap-3 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
+          <p className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1 font-medium leading-5 text-slate-500">
+            <span className="whitespace-nowrap">{footerBranding.brandName}</span>
+            <span aria-hidden="true" className="text-slate-300">·</span>
+            <span className="whitespace-nowrap">{footerBranding.productVersion}</span>
+            <span aria-hidden="true" className="text-slate-300">·</span>
+            <span className="whitespace-nowrap">{footerBranding.authorCredit}</span>
+          </p>
+          <a
+            href={branding.githubUrl}
+            target="_blank"
+            rel="noreferrer"
+            className="inline-flex min-h-8 shrink-0 items-center justify-center self-start rounded-full px-3 py-1.5 font-semibold leading-none text-slate-500 underline-offset-4 transition-colors duration-200 hover:bg-white/60 hover:text-slate-700 hover:underline sm:self-center"
+          >
+            {footerBranding.githubLabel}
+          </a>
         </div>
       </section>
     </section>

--- a/src/constants/authMessages.ts
+++ b/src/constants/authMessages.ts
@@ -1,0 +1,3 @@
+export const EMAIL_VERIFICATION_SENT_MESSAGE = '验证邮件已发送。请前往邮箱完成验证，验证完成后回到本页面登录。';
+export const EMAIL_VERIFIED_LOGIN_MESSAGE = '邮箱已验证，请返回登录页使用邮箱和密码登录。';
+export const EMAIL_NOT_CONFIRMED_MESSAGE = '邮箱尚未验证，请先查看邮箱验证邮件。没有收到可点击重新发送。';

--- a/src/constants/branding.ts
+++ b/src/constants/branding.ts
@@ -1,9 +1,17 @@
 export const branding = {
-  organizationName: 'Flysoon Labs',
+  organizationName: 'Flysoon Tech 飞升科技',
   productName: 'Visual Deadline',
   tagline: '可视：人生操作系统',
-  version: '1.0.1',
-  author: 'RanchoTao',
+  version: '2.0.0',
+  author: 'Rancho Tao',
   githubRepo: 'RanchoTao/Visualized-Deadline',
   githubUrl: 'https://github.com/RanchoTao/Visualized-Deadline',
+  githubButtonLabel: 'GitHub',
+} as const;
+
+export const footerBranding = {
+  brandName: branding.organizationName,
+  productVersion: `${branding.productName} v${branding.version}`,
+  authorCredit: `By ${branding.author}`,
+  githubLabel: branding.githubButtonLabel,
 } as const;

--- a/src/hooks/useSupabaseAuth.ts
+++ b/src/hooks/useSupabaseAuth.ts
@@ -1,37 +1,119 @@
 import { useCallback, useEffect, useState } from 'react';
+import { EMAIL_VERIFICATION_SENT_MESSAGE, EMAIL_VERIFIED_LOGIN_MESSAGE } from '../constants/authMessages';
 import { supabase, type SupabaseSession } from '../lib/supabaseClient';
 import type { UserProfile } from '../types/task';
 
 const EMAIL_CONFIRMATION_REDIRECT_URL = 'https://www.visualdeadline.com';
-const AUTH_CALLBACK_QUERY_PARAMS = ['code', 'state', 'error', 'error_code', 'error_description'];
+const AUTH_CALLBACK_PARAMS = [
+  'access_token',
+  'refresh_token',
+  'expires_in',
+  'token_type',
+  'type',
+  'code',
+  'state',
+  'error',
+  'error_code',
+  'error_description',
+];
 
-function readAuthCallbackCode(): string | null {
-  if (typeof window === 'undefined') return null;
-  return new URLSearchParams(window.location.search).get('code');
+interface AuthCallbackPayload {
+  accessToken: string | null;
+  refreshToken: string | null;
+  expiresIn?: number;
+  code: string | null;
+  type: string | null;
+  error: string | null;
 }
 
-function removeAuthCallbackQueryParams(): void {
+interface AuthCallbackResult {
+  session: SupabaseSession | null;
+  status?: string;
+}
+
+function readAuthCallbackParams(): AuthCallbackPayload | null {
+  if (typeof window === 'undefined') return null;
+  const queryParams = new URLSearchParams(window.location.search);
+  const rawHash = window.location.hash.startsWith('#') ? window.location.hash.slice(1) : window.location.hash;
+  const hashParams = new URLSearchParams(rawHash);
+  const getParam = (name: string) => queryParams.get(name) ?? hashParams.get(name);
+  const hasCallbackParam = AUTH_CALLBACK_PARAMS.some((param) => queryParams.has(param) || hashParams.has(param));
+  if (!hasCallbackParam) return null;
+
+  const rawExpiresIn = getParam('expires_in');
+  const expiresIn = rawExpiresIn ? Number(rawExpiresIn) : undefined;
+  const error = getParam('error_description') ?? getParam('error');
+
+  return {
+    accessToken: getParam('access_token'),
+    refreshToken: getParam('refresh_token'),
+    expiresIn: Number.isFinite(expiresIn) ? expiresIn : undefined,
+    code: getParam('code'),
+    type: getParam('type'),
+    error,
+  };
+}
+
+function removeAuthCallbackParams(): void {
   if (typeof window === 'undefined') return;
   const url = new URL(window.location.href);
-  AUTH_CALLBACK_QUERY_PARAMS.forEach((param) => url.searchParams.delete(param));
+  AUTH_CALLBACK_PARAMS.forEach((param) => url.searchParams.delete(param));
+
+  const hashWithoutPrefix = url.hash.startsWith('#') ? url.hash.slice(1) : url.hash;
+  if (hashWithoutPrefix) {
+    const hashParams = new URLSearchParams(hashWithoutPrefix);
+    AUTH_CALLBACK_PARAMS.forEach((param) => hashParams.delete(param));
+    const nextHash = hashParams.toString();
+    url.hash = nextHash ? `#${nextHash}` : '';
+  }
+
   const nextUrl = `${url.pathname}${url.search}${url.hash}`;
   window.history.replaceState(window.history.state, document.title, nextUrl);
+}
+
+async function handleAuthCallback(): Promise<AuthCallbackResult | null> {
+  const callbackParams = readAuthCallbackParams();
+  if (!callbackParams) return null;
+
+  try {
+    if (callbackParams.error) throw new Error(callbackParams.error);
+
+    if (callbackParams.accessToken && callbackParams.refreshToken) {
+      const session = await supabase.auth.setSession({
+        access_token: callbackParams.accessToken,
+        refresh_token: callbackParams.refreshToken,
+        expires_in: callbackParams.expiresIn,
+      });
+      return { session };
+    }
+
+    if (callbackParams.code || callbackParams.type === 'signup') {
+      await supabase.auth.acknowledgeEmailVerificationCallback();
+      return { session: null, status: EMAIL_VERIFIED_LOGIN_MESSAGE };
+    }
+
+    return null;
+  } finally {
+    removeAuthCallbackParams();
+  }
 }
 
 export function useSupabaseAuth() {
   const [session, setSession] = useState<SupabaseSession | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | undefined>();
+  const [status, setStatus] = useState<string | undefined>();
 
   useEffect(() => {
     let isMounted = true;
-    const callbackCode = readAuthCallbackCode();
-    const sessionPromise = callbackCode
-      ? supabase.auth.exchangeCodeForSession(callbackCode).then((exchangedSession) => {
-        removeAuthCallbackQueryParams();
-        return exchangedSession;
-      })
-      : supabase.auth.getSession();
+
+    const sessionPromise = handleAuthCallback().then(async (callbackResult) => {
+      if (callbackResult) {
+        if (isMounted) setStatus(callbackResult.status);
+        return callbackResult.session;
+      }
+      return supabase.auth.getSession();
+    });
 
     sessionPromise
       .then((currentSession) => {
@@ -53,6 +135,7 @@ export function useSupabaseAuth() {
 
   const signUp = useCallback(async (email: string, password: string, identity?: Pick<UserProfile, 'avatarDataUrl' | 'nickname' | 'username'>) => {
     setError(undefined);
+    setStatus(undefined);
     const nextSession = await supabase.auth.signUp({
       email,
       password,
@@ -71,16 +154,25 @@ export function useSupabaseAuth() {
 
   const signIn = useCallback(async (email: string, password: string) => {
     setError(undefined);
+    setStatus(undefined);
     const nextSession = await supabase.auth.signInWithPassword({ email, password });
     setSession(nextSession);
     return nextSession;
   }, []);
 
+  const resendVerificationEmail = useCallback(async (email: string) => {
+    setError(undefined);
+    setStatus(undefined);
+    await supabase.auth.resendVerificationEmail(email, EMAIL_CONFIRMATION_REDIRECT_URL);
+    setStatus(EMAIL_VERIFICATION_SENT_MESSAGE);
+  }, []);
+
   const signOut = useCallback(async () => {
     setError(undefined);
+    setStatus(undefined);
     await supabase.auth.signOut();
     setSession(null);
   }, []);
 
-  return { session, isLoading, error: error ?? supabase.configError, isConfigured: supabase.isConfigured, signUp, signIn, signOut };
+  return { session, isLoading, error: error ?? supabase.configError, status, isConfigured: supabase.isConfigured, signUp, signIn, resendVerificationEmail, signOut };
 }

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -40,6 +40,12 @@ interface SignUpCredentials extends EmailPasswordCredentials {
   };
 }
 
+interface SetSessionCredentials {
+  access_token: string;
+  refresh_token: string;
+  expires_in?: number;
+}
+
 const RAW_SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL as string | undefined;
 const RAW_SUPABASE_ANON_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY as string | undefined;
 const SESSION_STORAGE_KEY = 'vd.supabase.session';
@@ -307,12 +313,10 @@ class VisualDeadlineSupabaseClient {
       this.emit(session);
       return session;
     },
-    exchangeCodeForSession: async (code: string): Promise<SupabaseSession> => {
+    exchangeCodeForSession: async (code: string): Promise<SupabaseSession | null> => {
       const { url, anonKey } = getRequiredConfig();
       const codeVerifier = readStoredCodeVerifier();
-      if (!codeVerifier) {
-        throw new Error('无法完成邮箱验证登录：缺少本机验证凭据。请使用注册时的同一浏览器打开验证链接。');
-      }
+      if (!codeVerifier) return null;
       const payload = await parseResponse<{ access_token: string; refresh_token: string; expires_in?: number; user: SupabaseUser }>(await fetch(`${url}/auth/v1/token?grant_type=pkce`, {
         method: 'POST',
         headers: { apikey: anonKey, 'Content-Type': 'application/json' },
@@ -335,6 +339,30 @@ class VisualDeadlineSupabaseClient {
       persistSession(session);
       this.emit(session);
       return session;
+    },
+    setSession: async ({ access_token, refresh_token, expires_in }: SetSessionCredentials): Promise<SupabaseSession> => {
+      const { url, anonKey } = getRequiredConfig();
+      const user = await parseResponse<SupabaseUser>(await fetch(`${url}/auth/v1/user`, {
+        headers: { apikey: anonKey, Authorization: `Bearer ${access_token}` },
+      }));
+      const session = toSession({ access_token, refresh_token, expires_in, user });
+      persistSession(session);
+      clearStoredCodeVerifier();
+      this.emit(session);
+      return session;
+    },
+    resendVerificationEmail: async (email: string, emailRedirectTo?: string): Promise<void> => {
+      const { url, anonKey } = getRequiredConfig();
+      const resendUrl = new URL(`${url}/auth/v1/resend`);
+      if (emailRedirectTo) resendUrl.searchParams.set('redirect_to', emailRedirectTo);
+      await parseResponse<unknown>(await fetch(resendUrl, {
+        method: 'POST',
+        headers: { apikey: anonKey, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, type: 'signup' }),
+      }));
+    },
+    acknowledgeEmailVerificationCallback: async (): Promise<void> => {
+      clearStoredCodeVerifier();
     },
     refreshSession: async (refreshToken: string): Promise<SupabaseSession | null> => {
       const { url, anonKey } = getRequiredConfig();


### PR DESCRIPTION
### Motivation
- Properly handle Supabase auth callback parameters returned in URL query or hash to support OAuth/code and email verification flows. 
- Provide a way for users to resend email verification and show clear status messages during signup/login. 
- Refresh footer branding presentation and unify product metadata.

### Description
- Add `src/constants/authMessages.ts` with centralized email verification/status messages and use them across the UI and hooks. 
- Extend `useSupabaseAuth` to parse callback params (`readAuthCallbackParams`), handle auth callbacks (`handleAuthCallback`), expose a `status` string, and include a `resendVerificationEmail` helper; reset `status` on auth operations. 
- Implement new REST methods in `src/lib/supabaseClient.ts`: `setSession`, `resendVerificationEmail`, and `acknowledgeEmailVerificationCallback`, and adjust `exchangeCodeForSession` to return `null` when no verifier is present. 
- Update `AuthPanel` component to accept `status` and `onResendVerification`, display status messages, and add a "Resend verification" action and related UI/UX fixes for signup/signin flows. 
- Wire the new `status` and `resendVerificationEmail` through `App` so the `AuthPanel` receives the new props. 
- Update branding structure by refactoring `src/constants/branding.ts` and adjust `HomePage` footer to use `footerBranding` and a refreshed layout.

### Testing
- Ran TypeScript type checking with `tsc --noEmit` and the project build with `npm run build`, both completed successfully. 
- Ran unit tests and linters where configured with `npm test` and `npm run lint`, and they passed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ab6c18f74832c882a716a4fb5af43)