### PR TITLE
Remove avatarDataUrl from Supabase signup metadata

### DIFF
--- a/src/hooks/useSupabaseAuth.ts
+++ b/src/hooks/useSupabaseAuth.ts
@@ -169,7 +169,6 @@ export function useSupabaseAuth() {
       options: {
         emailRedirectTo: EMAIL_CONFIRMATION_REDIRECT_URL,
         data: identity ? {
-          avatarDataUrl: identity.avatarDataUrl,
           nickname: identity.nickname,
           username: identity.username,
         } : undefined,


### PR DESCRIPTION
### Motivation
- Prevent storing large base64 avatar data in Supabase Auth user metadata which can inflate the session/JWT and cause frontend session validation to fail.
- Only `nickname` and `username` should be sent to Supabase Auth metadata while the avatar remains managed in the app profile state and UI.

### Description
- Update `src/hooks/useSupabaseAuth.ts` to stop including `avatarDataUrl` in the `options.data` passed to `supabase.auth.signUp`, leaving only `nickname` and `username` when `identity` is provided.
- Preserve the `identity` parameter typing (`avatarDataUrl | nickname | username`) so local profile/avatar handling and UI upload logic remain unchanged.
- No other auth flow changes were made and `avatarDataUrl` is retained client-side rather than being written to Auth metadata.

### Testing
- Ran `npm run build` and the TypeScript/Vite build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0afd76a200832c9e0fc04c33c45f29)