### PR TITLE
feat: 进度排序、延后观察、压力分级与周报 v0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,17 @@ More demo ideas are documented in [`docs/DEMO_GIF_IDEAS.md`](./docs/DEMO_GIF_IDE
 
 ---
 
+## Weekly Update（本周更新）
+
+本周更新聚焦于：**降低任务系统压力，而不是增加焦虑**。
+
+- 活动列表现在默认按进度从高到低排序，并在进度相同时依次按重要性、是否有截止时间、截止时间先后进行比较。
+- 过期未完成任务新增派生状态 `delayed_observation`（中文：延后观察），用于降低视觉压迫感，不改变任务真实完成状态。
+- 新增压力分级：正常 / 轻微延迟 / 已堆积 / 严重堆积，以更柔和方式反映过期程度。
+- 新增周报系统 v0.1（本地计算版），统计本周完成、新增、高重要度、延后观察、严重堆积、平均进度与一句总结建议。
+
+---
+
 ## Architecture Overview
 
 VD is currently a Vite + React + TypeScript application with a local-first browser data model.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,6 +33,7 @@ import {
   normalizeProgressMode,
 } from './utils/taskScoring';
 import { appendPressureHistoryRecord, createPressureHistoryRecord, normalizePressureHistory } from './utils/pressureHistory';
+import { sortActiveTasksByProgress } from './utils/taskDerivedState';
 import { loadCloudData, saveCloudGoals, saveCloudPressureHistory, saveCloudProfile, saveCloudTasks } from './lib/cloudSync';
 import { hasValue, loadValue, savePressure, saveTasks, saveValue, storageKeys } from './storage';
 
@@ -386,7 +387,7 @@ function App() {
   const normalizedProfile = useMemo(() => normalizeProfile(profile), [profile]);
   const normalizedPressureCalibration = useMemo(() => normalizePressureCalibration(pressureCalibration, legacyReferencePressure), [legacyReferencePressure, pressureCalibration]);
   const normalizedPressureHistory = useMemo(() => normalizePressureHistory(pressureHistory), [pressureHistory]);
-  const activeTasks = useMemo(() => normalizedTasks.filter((task) => task.lifecycleStatus === 'active'), [normalizedTasks]);
+  const activeTasks = useMemo(() => sortActiveTasksByProgress(normalizedTasks.filter((task) => task.lifecycleStatus === 'active')), [normalizedTasks]);
   const recommendedTasks = useMemo(() => normalizedTasks.filter((task) => task.lifecycleStatus === 'active').sort((a, b) => getTaskScore(b) - getTaskScore(a)).slice(0, 3), [normalizedTasks]);
   const deadlinePressureTasks = useMemo(() => activeTasks.filter(isDeadlinePressureTask).sort((a, b) => getTaskScore(b) - getTaskScore(a)), [activeTasks]);
   const pressure = useMemo<PressureBreakdown>(() => calculatePressureIndex(normalizedTasks, normalizedPressureCalibration, legacyReferencePressure, new Date(pressureClock)), [normalizedTasks, normalizedPressureCalibration, legacyReferencePressure, pressureClock]);

--- a/src/components/TaskList.tsx
+++ b/src/components/TaskList.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import type { LifecycleStatus, Task } from '../types/task';
 import { formatCountdown, formatDeadline } from '../utils/date';
 import { getActivityTypeLabel, getDisplayProgress, getTaskProgress, getTimeProgress, isProgressAuto } from '../utils/taskScoring';
+import { calculatePressureLevel, getDerivedTaskStatus } from '../utils/taskDerivedState';
 import { ProgressBar } from './ProgressBar';
 
 interface TaskListProps {
@@ -18,6 +19,13 @@ export function TaskList({ tasks, onArchive, onDelete, onEdit }: TaskListProps) 
     action();
     setOpenMenuTaskId(undefined);
   }
+
+  const pressureLabelMap = {
+    normal: '正常',
+    light_delay: '轻微延迟',
+    accumulated: '已堆积',
+    severe_delay: '严重堆积',
+  } as const;
 
   return (
     <section className={`relative overflow-visible rounded-[2rem] border border-white/70 bg-white/75 p-5 shadow-xl shadow-slate-200/60 backdrop-blur ${openMenuTaskId ? 'z-40' : 'z-10'}`}>
@@ -39,6 +47,8 @@ export function TaskList({ tasks, onArchive, onDelete, onEdit }: TaskListProps) 
             const taskProgress = getTaskProgress(task);
             const timeProgress = getTimeProgress(task);
             const progressIsAuto = isProgressAuto(task);
+            const derivedStatus = getDerivedTaskStatus(task);
+            const pressureLevel = calculatePressureLevel(task);
 
             return (
               <li key={task.id} className={`relative overflow-visible rounded-3xl border border-white/80 bg-slate-50/80 p-4 shadow-sm shadow-slate-100/70 ${isMenuOpen ? 'z-50' : 'z-0'}`}>
@@ -51,8 +61,11 @@ export function TaskList({ tasks, onArchive, onDelete, onEdit }: TaskListProps) 
                     {task.description ? <p className="mt-2 line-clamp-2 text-sm text-slate-600">{task.description}</p> : null}
                     <div className="mt-3 flex flex-wrap gap-2 text-xs text-slate-500">
                       <span className="rounded-full bg-white px-2.5 py-1">重要性 {task.importance}/10</span>
-                      <span className="rounded-full bg-white px-2.5 py-1">{formatCountdown(task.deadline)}</span>
+                      <span className={`rounded-full px-2.5 py-1 ${derivedStatus === 'delayed_observation' ? 'bg-amber-50 text-amber-700' : 'bg-white'}`}>
+                        {derivedStatus === 'delayed_observation' ? '延后观察' : formatCountdown(task.deadline)}
+                      </span>
                       <span className="rounded-full bg-white px-2.5 py-1">截止 {formatDeadline(task.deadline)}</span>
+                      <span className={`rounded-full px-2.5 py-1 ${pressureLevel === 'severe_delay' ? 'bg-amber-100 text-amber-800' : 'bg-slate-100 text-slate-600'}`}>{pressureLabelMap[pressureLevel]}</span>
                     </div>
                     <div className="mt-3 max-w-sm">
                       <ProgressBar progress={displayProgress} compact />

--- a/src/components/TaskPage.tsx
+++ b/src/components/TaskPage.tsx
@@ -4,6 +4,7 @@ import { AITaskAnalysisPanel } from './AITaskAnalysisPanel';
 import { AITaskCommandBar } from './AITaskCommandBar';
 import { PriorityMap } from './PriorityMap';
 import { TaskList } from './TaskList';
+import { generateWeeklyReport } from '../utils/weeklyReport';
 
 interface TaskPageProps {
   tasks: Task[];
@@ -21,6 +22,8 @@ interface TaskPageProps {
 }
 
 export function TaskPage({ tasks, activeTasks, achievements, pressure, onAddTask, onConfirmAITasks, onArchiveTask, onDeleteTask, onEditTask, onAIConnected, onAIArtifactGenerated, onAIReportGenerated }: TaskPageProps) {
+  const weeklyReport = generateWeeklyReport(tasks);
+
   return (
     <section className="space-y-6">
       <header className="flex flex-wrap items-center justify-between gap-4 rounded-[2rem] border border-white/70 bg-white/75 p-6 shadow-xl shadow-slate-200/60 backdrop-blur">
@@ -35,6 +38,21 @@ export function TaskPage({ tasks, activeTasks, achievements, pressure, onAddTask
       </header>
 
       <AITaskCommandBar tasks={tasks} onConfirmTasks={onConfirmAITasks} onAIArtifactGenerated={onAIArtifactGenerated} />
+      <section className="rounded-[2rem] border border-white/70 bg-white/75 p-5 shadow-xl shadow-slate-200/60 backdrop-blur">
+        <div className="mb-3 flex items-center justify-between">
+          <h2 className="text-xl font-semibold text-slate-900">周报 v0.1</h2>
+          <span className="rounded-full bg-slate-100 px-3 py-1 text-xs text-slate-600">本周一 00:00 至今</span>
+        </div>
+        <div className="grid gap-2 text-sm text-slate-700 sm:grid-cols-2 lg:grid-cols-3">
+          <p>本周完成任务数：{weeklyReport.completedThisWeek}</p>
+          <p>本周新增任务数：{weeklyReport.createdThisWeek}</p>
+          <p>本周高重要度任务数：{weeklyReport.highImportanceThisWeek}</p>
+          <p>当前延后观察任务数：{weeklyReport.delayedObservationCount}</p>
+          <p>当前严重堆积任务数：{weeklyReport.severeDelayCount}</p>
+          <p>平均任务进度：{weeklyReport.averageProgress}%</p>
+        </div>
+        <p className="mt-3 rounded-2xl bg-slate-50 px-3 py-2 text-sm text-slate-600">{weeklyReport.summary}</p>
+      </section>
       <PriorityMap tasks={activeTasks} />
       <AITaskAnalysisPanel tasks={tasks} pressure={pressure} onAIConnected={onAIConnected} onAIReportGenerated={onAIReportGenerated} />
       <TaskList tasks={activeTasks} onArchive={onArchiveTask} onDelete={onDeleteTask} onEdit={onEditTask} />

--- a/src/utils/taskDerivedState.ts
+++ b/src/utils/taskDerivedState.ts
@@ -1,0 +1,57 @@
+import type { Task } from '../types/task';
+import { getDisplayProgress } from './taskScoring';
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+export type DerivedTaskStatus = 'active' | 'completed' | 'abandoned' | 'delayed_observation';
+export type PressureLevel = 'normal' | 'light_delay' | 'accumulated' | 'severe_delay';
+
+function getDeadlineDiffMs(deadline?: string, now = new Date()): number | undefined {
+  if (!deadline) return undefined;
+  const deadlineMs = new Date(deadline).getTime();
+  if (!Number.isFinite(deadlineMs)) return undefined;
+  return now.getTime() - deadlineMs;
+}
+
+export function getDerivedTaskStatus(task: Task, now = new Date()): DerivedTaskStatus {
+  if (task.lifecycleStatus === 'completed') return 'completed';
+  if (task.lifecycleStatus === 'abandoned') return 'abandoned';
+
+  const diffMs = getDeadlineDiffMs(task.deadline, now);
+  if (typeof diffMs === 'number' && diffMs > 0) return 'delayed_observation';
+  return 'active';
+}
+
+export function calculatePressureLevel(task: Task, now = new Date()): PressureLevel {
+  if (task.lifecycleStatus === 'completed') return 'normal';
+  const diffMs = getDeadlineDiffMs(task.deadline, now);
+  if (typeof diffMs !== 'number' || diffMs <= 0) return 'normal';
+
+  if (diffMs <= MS_PER_DAY) return 'light_delay';
+  if (diffMs <= 7 * MS_PER_DAY) return 'accumulated';
+  return 'severe_delay';
+}
+
+export function sortActiveTasksByProgress(tasks: Task[], now = new Date()): Task[] {
+  return [...tasks].sort((a, b) => {
+    const progressDiff = getDisplayProgress(b, now) - getDisplayProgress(a, now);
+    if (progressDiff !== 0) return progressDiff;
+
+    const importanceDiff = b.importance - a.importance;
+    if (importanceDiff !== 0) return importanceDiff;
+
+    const aHasDeadline = Boolean(a.deadline);
+    const bHasDeadline = Boolean(b.deadline);
+    if (aHasDeadline !== bHasDeadline) return aHasDeadline ? -1 : 1;
+
+    if (!a.deadline || !b.deadline) return 0;
+
+    const aDeadline = new Date(a.deadline).getTime();
+    const bDeadline = new Date(b.deadline).getTime();
+    if (!Number.isFinite(aDeadline) && !Number.isFinite(bDeadline)) return 0;
+    if (!Number.isFinite(aDeadline)) return 1;
+    if (!Number.isFinite(bDeadline)) return -1;
+    return aDeadline - bDeadline;
+  });
+}
+

--- a/src/utils/weeklyReport.ts
+++ b/src/utils/weeklyReport.ts
@@ -1,0 +1,62 @@
+import type { Task } from '../types/task';
+import { calculatePressureLevel, getDerivedTaskStatus } from './taskDerivedState';
+
+export interface WeeklyReport {
+  completedThisWeek: number;
+  createdThisWeek: number;
+  highImportanceThisWeek: number;
+  delayedObservationCount: number;
+  severeDelayCount: number;
+  averageProgress: number;
+  summary: string;
+}
+
+function getWeekStart(now = new Date()): Date {
+  const date = new Date(now);
+  const day = date.getDay();
+  const diffToMonday = day === 0 ? 6 : day - 1;
+  date.setHours(0, 0, 0, 0);
+  date.setDate(date.getDate() - diffToMonday);
+  return date;
+}
+
+function toTime(value?: string): number | undefined {
+  if (!value) return undefined;
+  const time = new Date(value).getTime();
+  return Number.isFinite(time) ? time : undefined;
+}
+
+export function generateWeeklyReport(items: Task[], now = new Date()): WeeklyReport {
+  const weekStart = getWeekStart(now).getTime();
+  const nowTime = now.getTime();
+
+  const completedThisWeek = items.filter((task) => {
+    if (task.lifecycleStatus !== 'completed') return false;
+    // If completedAt is missing, we approximate with updatedAt to keep weekly stats usable.
+    const completedTime = toTime(task.completedAt) ?? toTime(task.updatedAt);
+    return typeof completedTime === 'number' && completedTime >= weekStart && completedTime <= nowTime;
+  }).length;
+
+  const createdThisWeek = items.filter((task) => {
+    const createdTime = toTime(task.createdAt);
+    return typeof createdTime === 'number' && createdTime >= weekStart && createdTime <= nowTime;
+  }).length;
+
+  const highImportanceThisWeek = items.filter((task) => {
+    const createdTime = toTime(task.createdAt);
+    return task.importance >= 8 && typeof createdTime === 'number' && createdTime >= weekStart && createdTime <= nowTime;
+  }).length;
+
+  const delayedObservationCount = items.filter((task) => getDerivedTaskStatus(task, now) === 'delayed_observation').length;
+  const severeDelayCount = items.filter((task) => calculatePressureLevel(task, now) === 'severe_delay').length;
+
+  const averageProgress = items.length === 0 ? 0 : Math.round(items.reduce((sum, task) => sum + task.progress, 0) / items.length);
+
+  let summary = '本周数据还不够多，先从记录和完成一件小事开始。';
+  if (completedThisWeek > 0) summary = '你这周已经完成了一部分任务，不是毫无进展。';
+  else if (severeDelayCount >= 3) summary = '部分任务已经长期堆积，建议删除、拆分或重新定义。';
+  else if (delayedObservationCount >= 3) summary = '当前系统检测到一些延后任务，建议只挑 1-3 件重新启动。';
+
+  return { completedThisWeek, createdThisWeek, highImportanceThisWeek, delayedObservationCount, severeDelayCount, averageProgress, summary };
+}
+


### PR DESCRIPTION
### Motivation

- 降低过期未完成任务带来的视觉和心理压力，而不改变任务数据语义或做大规模重构。 
- 提供稳定、可复用的活动排序逻辑以便后续测试与扩展。 
- 增加一版本地周报用于快速了解本周进展与压力分布（不接入 AI）。

### Description

- 新增派生状态与压力工具文件 `src/utils/taskDerivedState.ts`，实现 `getDerivedTaskStatus(task, now)`（支持 `delayed_observation`/“延后观察”）、`calculatePressureLevel(task, now)`（`normal`/`light_delay`/`accumulated`/`severe_delay`）及独立排序函数 `sortActiveTasksByProgress(tasks, now)`。 
- 新增周报生成器 `src/utils/weeklyReport.ts`，提供 `generateWeeklyReport(items, now)`，统计本周完成、新增、高重要度（importance >= 8）、延后观察、严重堆积、平均进度并生成一句中文总结，且在 `completedAt` 缺失时使用 `updatedAt` 作为近似（并在代码注释中说明）。 
- 将排序函数接入主流计算入口：在 `src/App.tsx` 中将 `activeTasks` 改为使用 `sortActiveTasksByProgress(...)` 以实现要求的四级排序（进度→重要性→是否有截止→截止时间先后）。 
- 在 UI 层改动：`src/components/TaskList.tsx` 增加延后观察展示与中文压力 badge（视觉柔和，只有 `severe_delay` 略醒目），并保持原有完成/编辑/删除等操作不变；`src/components/TaskPage.tsx` 新增简洁的“周报 v0.1”卡片入口以展示生成的周报。 
- 文档更新：在 `README.md` 添加 “Weekly Update（本周更新）” 节，概述本次改动与目标（降低任务系统压力，而不是增加焦虑）。

### Testing

- 已运行构建：执行 `npm run build` 成功（构建通过）。
- 项目没有自动化测试与 lint 脚本：仓库 `package.json` 未包含 `npm test` 或 `lint`，因此未运行单元/集成测试或静态检查。 
- 建议后续为 `sortActiveTasksByProgress`、`calculatePressureLevel` 与 `generateWeeklyReport` 补充单元测试以验证排序和分级边界情况。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a129035b898832ca3c0832d2e98402d)