### PR TITLE
VD v0.3 — Flow State: 轻量视觉与动效升级

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1019,7 +1019,9 @@ function App() {
           onSignIn={() => setHasChosenGuestMode(false)}
           onSignOut={signOut}
         />
-        {moduleContent[activeModule]}
+        <div key={activeModule} className="vd-module-transition">
+          {moduleContent[activeModule]}
+        </div>
       </div>
       <MobileBottomNav activeModule={activeModule} onModuleChange={setActiveModule} />
     </main>

--- a/src/components/ProgressBar.tsx
+++ b/src/components/ProgressBar.tsx
@@ -1,10 +1,13 @@
+import { memo } from 'react';
+
 interface ProgressBarProps {
   progress: number;
   compact?: boolean;
 }
 
-export function ProgressBar({ progress, compact = false }: ProgressBarProps) {
+function ProgressBarComponent({ progress, compact = false }: ProgressBarProps) {
   const normalizedProgress = Math.min(100, Math.max(0, progress));
+  const toneClass = normalizedProgress >= 75 ? 'bg-sky-500' : normalizedProgress >= 45 ? 'bg-sky-600' : 'bg-slate-500';
 
   return (
     <div className="w-full">
@@ -12,9 +15,11 @@ export function ProgressBar({ progress, compact = false }: ProgressBarProps) {
         <span>进度</span>
         <span>{normalizedProgress}%</span>
       </div>
-      <div className={`mt-1 overflow-hidden rounded-full bg-slate-200 ${compact ? 'h-1.5' : 'h-2.5'}`}>
-        <div className="h-full rounded-full bg-sky-500 transition-all" style={{ width: `${normalizedProgress}%` }} />
+      <div className={`mt-1 overflow-hidden rounded-full bg-slate-200/80 ${compact ? 'h-1.5' : 'h-2.5'}`}>
+        <div className={`h-full rounded-full ${toneClass} transition-[width,background-color] duration-300 ease-out`} style={{ width: `${normalizedProgress}%` }} />
       </div>
     </div>
   );
 }
+
+export const ProgressBar = memo(ProgressBarComponent);

--- a/src/components/TaskList.tsx
+++ b/src/components/TaskList.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { memo, useState } from 'react';
 import type { LifecycleStatus, Task } from '../types/task';
 import { formatCountdown, formatDeadline } from '../utils/date';
 import { getActivityTypeLabel, getDisplayProgress, getTaskProgress, getTimeProgress, isProgressAuto } from '../utils/taskScoring';
@@ -12,7 +12,7 @@ interface TaskListProps {
   onEdit: (task: Task) => void;
 }
 
-export function TaskList({ tasks, onArchive, onDelete, onEdit }: TaskListProps) {
+function TaskListComponent({ tasks, onArchive, onDelete, onEdit }: TaskListProps) {
   const [openMenuTaskId, setOpenMenuTaskId] = useState<string | undefined>();
 
   function runAction(action: () => void) {
@@ -38,7 +38,11 @@ export function TaskList({ tasks, onArchive, onDelete, onEdit }: TaskListProps) 
       </div>
 
       {tasks.length === 0 ? (
-        <div className="mt-6 rounded-3xl border border-dashed border-slate-200 p-8 text-center text-slate-500">暂无进行中的项目。</div>
+        <div className="mt-6 rounded-3xl border border-dashed border-slate-200/90 bg-white/55 p-9 text-center text-slate-500">
+          <div className="mx-auto mb-3 flex h-11 w-11 vd-empty-state-icon items-center justify-center rounded-2xl bg-slate-100 text-slate-500">◎</div>
+          <p className="text-sm font-medium text-slate-600">Nothing urgent right now.</p>
+          <p className="mt-1 text-xs text-slate-400">Clear mind. Clear system.</p>
+        </div>
       ) : (
         <ul className="mt-5 grid overflow-visible gap-3 lg:grid-cols-2">
           {tasks.map((task) => {
@@ -51,11 +55,12 @@ export function TaskList({ tasks, onArchive, onDelete, onEdit }: TaskListProps) 
             const pressureLevel = calculatePressureLevel(task);
 
             return (
-              <li key={task.id} className={`relative overflow-visible rounded-3xl border border-white/80 bg-slate-50/80 p-4 shadow-sm shadow-slate-100/70 ${isMenuOpen ? 'z-50' : 'z-0'}`}>
+              <li key={task.id} className={`vd-task-enter vd-task-card relative overflow-visible rounded-3xl border bg-slate-50/85 p-4 shadow-sm shadow-slate-100/70 ${task.progress >= 100 ? 'border-emerald-100/90 opacity-75 scale-[0.995]' : 'border-white/80 hover:border-sky-100/90 hover:shadow-md hover:shadow-slate-200/80'} ${isMenuOpen ? 'z-50' : 'z-0'}`}>
                 <div className="flex items-start justify-between gap-3">
                   <div className="min-w-0 flex-1">
                     <div className="flex flex-wrap items-center gap-2">
-                      <h3 className="font-semibold text-slate-950">{task.title}</h3>
+                      <h3 className={`font-semibold text-slate-950 ${task.progress >= 100 ? 'vd-strike text-slate-500' : ''}`}>{task.title}</h3>
+                      {task.progress >= 100 ? <span className="inline-flex h-5 w-5 items-center justify-center rounded-full bg-emerald-100 text-xs text-emerald-700 transition-all duration-200 ease-out">✓</span> : null}
                       <span className="rounded-full bg-white px-2.5 py-1 text-xs font-medium text-slate-500">{getActivityTypeLabel(task.activityType)}</span>
                     </div>
                     {task.description ? <p className="mt-2 line-clamp-2 text-sm text-slate-600">{task.description}</p> : null}
@@ -109,3 +114,5 @@ export function TaskList({ tasks, onArchive, onDelete, onEdit }: TaskListProps) 
     </section>
   );
 }
+
+export const TaskList = memo(TaskListComponent);

--- a/src/styles.css
+++ b/src/styles.css
@@ -10,6 +10,13 @@
   -moz-osx-font-smoothing: grayscale;
 }
 
+/* VD v0.3 — Flow State motion tokens */
+:root {
+  --vd-ease-out: cubic-bezier(0.22, 1, 0.36, 1);
+  --vd-hover-duration: 150ms;
+  --vd-enter-duration: 240ms;
+}
+
 button,
 input,
 select,
@@ -45,4 +52,69 @@ textarea {
 
 .animate-soft-rise {
   animation: soft-rise 0.42s ease-out both;
+}
+
+@keyframes vd-fade-slide-up {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes vd-line-through {
+  from {
+    transform: scaleX(0);
+    opacity: 0;
+  }
+  to {
+    transform: scaleX(1);
+    opacity: 1;
+  }
+}
+
+@keyframes vd-empty-float {
+  0%, 100% { transform: translateY(0); }
+  50% { transform: translateY(-4px); }
+}
+
+.vd-module-transition {
+  animation: vd-fade-slide-up var(--vd-enter-duration) var(--vd-ease-out) both;
+}
+
+.vd-task-enter {
+  animation: vd-fade-slide-up var(--vd-enter-duration) var(--vd-ease-out) both;
+}
+
+.vd-task-card {
+  transform: translateZ(0);
+  transition: box-shadow var(--vd-hover-duration) var(--vd-ease-out), transform var(--vd-hover-duration) var(--vd-ease-out), border-color var(--vd-hover-duration) var(--vd-ease-out), opacity 220ms var(--vd-ease-out);
+  will-change: transform;
+}
+
+.vd-task-card:hover {
+  transform: translateY(-2px) translateZ(0);
+}
+
+.vd-strike {
+  position: relative;
+}
+
+.vd-strike::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 50%;
+  height: 1.5px;
+  transform-origin: left;
+  background: color-mix(in srgb, #64748b 65%, transparent);
+  animation: vd-line-through 220ms var(--vd-ease-out) both;
+}
+
+.vd-empty-state-icon {
+  animation: vd-empty-float 2.8s ease-in-out infinite;
 }


### PR DESCRIPTION
### Motivation
- 引入一致且克制的动效节奏以提升界面质感与交互反馈，同时避免游戏化或过度弹簧效果。 
- 在不增加功能复杂度的前提下，优化任务卡片、进度条、空状态与页面切换的视觉与动画体验以强化“效率工具”感。 
- 保持性能优先，尽量减少重绘与不必要的 rerender，并为后续扩展留出可控的动效 token。 

### Description
- 增加全局 motion token 与关键帧（`src/styles.css`）：定义 `--vd-ease-out`、hover/enter 时长、`vd-fade-slide-up`、`vd-line-through`、`vd-empty-float` 等可复用样式类。 
- 任务卡片视觉与交互调整（`src/components/TaskList.tsx`）：卡片入场为 fade+slide-up，hover 时轻微上浮与边框高亮，完成态加入 check 图标、strike-through 动画与轻微透明/缩放效果，空状态替换为极简高级布局与克制文案。 
- 进度条平滑过渡（`src/components/ProgressBar.tsx`）：使用 `width` + `background-color` 过渡（300ms ease-out）并根据进度分配低/中/高色调；同时对 `ProgressBar` 与 `TaskList` 使用 `memo` 优化渲染。 
- 页面模块切换加入淡入+轻上移包装（`src/App.tsx`），并在动效中使用 `translateZ(0)` 与 `will-change: transform` 来减少抖动与提升 GPU 加速。 
- 修改文件：`src/styles.css`, `src/components/TaskList.tsx`, `src/components/ProgressBar.tsx`, `src/App.tsx`。 

### Testing
- 运行构建：`npm run build` 成功通过。 
- 尝试自动截图以验证页面外观时受环境限制失败（安装 Playwright 时 npm registry 返回 `403 Forbidden`），截图未生成。 
- 未添加新的单元测试；所有变更均为视觉/界面层面且通过生产构建验证。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17b827525c832c8292a48187c370de)