### PR TITLE
长期目标：节点式路线图、中文日期占位与 AI 草稿摘要

### DIFF
--- a/src/components/AITaskCommandBar.tsx
+++ b/src/components/AITaskCommandBar.tsx
@@ -29,7 +29,6 @@ export function AITaskCommandBar({ tasks, onConfirmTasks, onAIArtifactGenerated 
   const [state, setState] = useState<IntakeState>('idle');
   const [drafts, setDrafts] = useState<TaskInput[]>([]);
   const [notes, setNotes] = useState('');
-  const [rawJson, setRawJson] = useState('');
   const [errorMessage, setErrorMessage] = useState('');
   const [canResetAuthState, setCanResetAuthState] = useState(false);
 
@@ -48,7 +47,6 @@ export function AITaskCommandBar({ tasks, onConfirmTasks, onAIArtifactGenerated 
     setCanResetAuthState(false);
     setDrafts([]);
     setNotes('');
-    setRawJson('');
     try {
       const payload = createTaskIntakePayload(trimmedInput, tasks);
       const taskContext = tasks
@@ -66,7 +64,6 @@ export function AITaskCommandBar({ tasks, onConfirmTasks, onAIArtifactGenerated 
       const parsed = parseTaskIntakeResponse(result);
       setDrafts(parsed.tasks);
       setNotes(parsed.notes);
-      setRawJson(parsed.rawJson);
       setState('ready');
       onAIArtifactGenerated?.({
         kind: 'task-intake',
@@ -90,7 +87,6 @@ export function AITaskCommandBar({ tasks, onConfirmTasks, onAIArtifactGenerated 
     setInput('');
     setDrafts([]);
     setNotes('');
-    setRawJson('');
     setCanResetAuthState(false);
     setState('idle');
   }
@@ -98,7 +94,6 @@ export function AITaskCommandBar({ tasks, onConfirmTasks, onAIArtifactGenerated 
   function cancelDrafts() {
     setDrafts([]);
     setNotes('');
-    setRawJson('');
     setErrorMessage('');
     setCanResetAuthState(false);
     setState('idle');
@@ -108,11 +103,6 @@ export function AITaskCommandBar({ tasks, onConfirmTasks, onAIArtifactGenerated 
     await resetCloudAIAuthState();
     setCanResetAuthState(false);
     setErrorMessage('已清除登录缓存。请重新登录后再使用 VD Cloud AI。');
-  }
-
-  async function copyJson() {
-    if (!rawJson || !navigator.clipboard) return;
-    await navigator.clipboard.writeText(rawJson);
   }
 
   return (
@@ -153,7 +143,6 @@ export function AITaskCommandBar({ tasks, onConfirmTasks, onAIArtifactGenerated 
               <h3 className="text-lg font-semibold">待确认任务草稿</h3>
               {notes ? <p className="mt-1 text-sm text-slate-500">{notes}</p> : null}
             </div>
-            {rawJson ? <button type="button" onClick={copyJson} className="rounded-full bg-slate-100 px-3 py-1.5 text-xs font-semibold text-slate-500 hover:bg-slate-200">复制 JSON</button> : null}
           </div>
           {drafts.length === 0 ? (
             <div className="mt-4 rounded-2xl border border-dashed border-slate-200 p-5 text-center text-sm text-slate-400">没有识别到明确任务。</div>

--- a/src/components/GoalRoadmapPanel.tsx
+++ b/src/components/GoalRoadmapPanel.tsx
@@ -19,6 +19,7 @@ const categories = ['study', 'research', 'fitness', 'work', 'life', 'social', 'o
 const roadmapFacets = ['AI 路线图', '阶段拆解', '风险分析', '周期建议'] as const;
 
 type RoadmapState = { loadingGoalId?: string; errorGoalId?: string; message?: string };
+type RoadmapNode = { id: string; title: string; timeRange: string; summary: string; details: string[] };
 
 function createGoalInput(goal: Goal): GoalInput {
   return {
@@ -31,8 +32,39 @@ function createGoalInput(goal: Goal): GoalInput {
   };
 }
 
-function getPreviewItems(goal: Goal) {
-  return goal.roadmapSuggestions?.slice(0, 2) ?? [];
+function splitSuggestion(item: string): { section: string; content: string } {
+  const separatorIndex = item.indexOf('：');
+  if (separatorIndex < 0) return { section: '阶段', content: item.trim() };
+  return { section: item.slice(0, separatorIndex).trim(), content: item.slice(separatorIndex + 1).trim() };
+}
+
+function getRoadmapNodes(goal: Goal): RoadmapNode[] {
+  const suggestions = goal.roadmapSuggestions ?? [];
+  const grouped = suggestions.reduce<Record<string, string[]>>((result, item) => {
+    const { section, content } = splitSuggestion(item);
+    (result[section] ??= []).push(content);
+    return result;
+  }, {});
+  const stages = grouped['阶段']?.length ? grouped['阶段'] : suggestions.slice(0, 4);
+  return stages.map((stage, index) => {
+    const [rawTitle, rawTimeRange, rawSummary] = stage.split('｜').map((item) => item.trim());
+    const summary = rawSummary || rawTitle || `推进阶段 ${index + 1}`;
+    return {
+      id: `${goal.id}-stage-${index}`,
+      title: rawSummary ? rawTitle : `阶段 ${index + 1}`,
+      timeRange: rawTimeRange || '时间范围待确认',
+      summary,
+      details: [
+        grouped['里程碑']?.[index] ? `里程碑：${grouped['里程碑'][index]}` : undefined,
+        grouped['周/月方向']?.[index] ? `推进节奏：${grouped['周/月方向'][index]}` : undefined,
+        index === 0 && grouped['第一步行动']?.[0] ? `第一步：${grouped['第一步行动'][0]}` : undefined,
+      ].filter((item): item is string => Boolean(item)),
+    };
+  });
+}
+
+function getRoadmapNotes(goal: Goal): string[] {
+  return (goal.roadmapSuggestions ?? []).filter((item) => splitSuggestion(item).section !== '阶段');
 }
 
 export function GoalRoadmapPanel({ goals, tasks, onSaveGoal, onDeleteGoal, onRoadmapGenerated }: GoalRoadmapPanelProps) {
@@ -45,7 +77,12 @@ export function GoalRoadmapPanel({ goals, tasks, onSaveGoal, onDeleteGoal, onRoa
   const [editingGoalId, setEditingGoalId] = useState<string | undefined>();
   const [expandedGoalId, setExpandedGoalId] = useState<string | undefined>();
   const [roadmapState, setRoadmapState] = useState<RoadmapState>({});
+  const [expandedNodeIds, setExpandedNodeIds] = useState<string[]>([]);
   const isEditing = Boolean(editingGoalId);
+
+  function toggleNode(nodeId: string) {
+    setExpandedNodeIds((current) => current.includes(nodeId) ? current.filter((id) => id !== nodeId) : [...current, nodeId]);
+  }
 
   useEffect(() => {
     if (expandedGoalId && !goals.some((goal) => goal.id === expandedGoalId)) setExpandedGoalId(undefined);
@@ -141,7 +178,10 @@ export function GoalRoadmapPanel({ goals, tasks, onSaveGoal, onDeleteGoal, onRoa
         </label>
         <label className="space-y-2 text-xs font-semibold text-slate-400">
           时间跨度
-          <input type="date" value={targetDate} onChange={(event) => setTargetDate(event.target.value)} className="w-full rounded-2xl border border-transparent bg-white/85 px-4 py-3 text-sm text-slate-700 outline-none transition focus:border-sky-100 focus:ring-4 focus:ring-sky-100/60" />
+          <span className="relative block">
+            {!targetDate ? <span className="pointer-events-none absolute inset-y-0 left-4 flex items-center text-sm font-normal text-slate-400">选择日期</span> : null}
+            <input aria-label="截止日期" type="date" value={targetDate} onChange={(event) => setTargetDate(event.target.value)} className={`w-full rounded-2xl border border-transparent bg-white/85 px-4 py-3 text-sm outline-none transition focus:border-sky-100 focus:ring-4 focus:ring-sky-100/60 ${targetDate ? 'text-slate-700' : 'text-transparent'}`} />
+          </span>
         </label>
         <label className="space-y-2 text-xs font-semibold text-slate-400">
           领域
@@ -164,7 +204,8 @@ export function GoalRoadmapPanel({ goals, tasks, onSaveGoal, onDeleteGoal, onRoa
           {goals.map((goal) => {
             const isExpanded = expandedGoalId === goal.id;
             const isLoading = roadmapState.loadingGoalId === goal.id;
-            const previewItems = getPreviewItems(goal);
+            const roadmapNodes = getRoadmapNodes(goal);
+            const roadmapNotes = getRoadmapNotes(goal);
             return (
               <article key={goal.id} className="rounded-[1.5rem] border border-white/80 bg-white/80 p-4 shadow-sm ring-1 ring-white/80">
                 <div className="flex flex-wrap items-start justify-between gap-3">
@@ -188,9 +229,9 @@ export function GoalRoadmapPanel({ goals, tasks, onSaveGoal, onDeleteGoal, onRoa
                 {roadmapState.errorGoalId === goal.id && roadmapState.message ? <p className="mt-3 rounded-2xl bg-rose-50 px-4 py-3 text-sm font-semibold text-rose-600 ring-1 ring-rose-100">{roadmapState.message}</p> : null}
                 {isLoading ? <p className="mt-3 rounded-2xl bg-sky-50 px-4 py-3 text-sm font-semibold text-sky-700 ring-1 ring-sky-100">正在生成路线图建议……</p> : null}
 
-                {!isExpanded && previewItems.length ? (
+                {!isExpanded && roadmapNodes.length ? (
                   <div className="mt-3 flex flex-wrap gap-2">
-                    {previewItems.map((item, index) => <span key={`${item}-${index}`} className="max-w-full truncate rounded-full bg-slate-50 px-3 py-1 text-xs text-slate-500 ring-1 ring-slate-100">{item}</span>)}
+                    {roadmapNodes.slice(0, 2).map((node) => <span key={node.id} className="max-w-full truncate rounded-full bg-slate-50 px-3 py-1 text-xs text-slate-500 ring-1 ring-slate-100">{node.title} · {node.summary}</span>)}
                   </div>
                 ) : null}
 
@@ -199,10 +240,30 @@ export function GoalRoadmapPanel({ goals, tasks, onSaveGoal, onDeleteGoal, onRoa
                     <div className="grid gap-2 md:grid-cols-4">
                       {roadmapFacets.map((facet) => <div key={facet} className="rounded-2xl bg-white/80 px-3 py-2 text-xs font-semibold text-slate-500 ring-1 ring-white/80">{facet}</div>)}
                     </div>
-                    {goal.roadmapSuggestions?.length ? (
-                      <ol className="mt-4 space-y-2 text-sm text-slate-600">
-                        {goal.roadmapSuggestions.map((item, index) => <li key={`${item}-${index}`} className="rounded-2xl bg-white/85 px-4 py-3 leading-6 ring-1 ring-white/80"><span className="mr-2 font-semibold text-slate-400">{index + 1}.</span>{item}</li>)}
-                      </ol>
+                    {roadmapNodes.length ? (
+                      <div className="mt-5">
+                        <ol className="space-y-0">
+                          {roadmapNodes.map((node, index) => {
+                            const isNodeExpanded = expandedNodeIds.includes(node.id);
+                            return <li key={node.id} className="relative pl-7">
+                              {index < roadmapNodes.length - 1 ? <span className="absolute left-[0.55rem] top-5 h-full w-px bg-slate-200" /> : null}
+                              <span className="absolute left-0 top-4 h-[1.15rem] w-[1.15rem] rounded-full border-4 border-white bg-slate-800 shadow-sm" />
+                              <article className="mb-3 rounded-2xl bg-white/85 p-4 ring-1 ring-slate-100">
+                                <div className="flex flex-wrap items-start justify-between gap-3">
+                                  <div className="min-w-0 flex-1">
+                                    <p className="text-xs font-semibold text-slate-400">{node.timeRange}</p>
+                                    <h4 className="mt-1 font-semibold text-slate-900">{node.title}</h4>
+                                    <p className="mt-1 text-sm leading-6 text-slate-500">{node.summary}</p>
+                                  </div>
+                                  <button type="button" onClick={() => toggleNode(node.id)} className="rounded-full bg-slate-50 px-3 py-1.5 text-xs font-semibold text-slate-600 ring-1 ring-slate-100 hover:bg-slate-100">{isNodeExpanded ? '收起' : '展开'}</button>
+                                </div>
+                                {isNodeExpanded ? <div className="mt-3 border-t border-slate-100 pt-3 text-xs leading-6 text-slate-500">{node.details.length ? node.details.map((detail) => <p key={detail}>{detail}</p>) : <p>核心行动：{node.summary}</p>}</div> : null}
+                              </article>
+                            </li>;
+                          })}
+                        </ol>
+                        {roadmapNotes.length ? <div className="mt-3 flex flex-wrap gap-2">{roadmapNotes.map((item, index) => <span key={`${item}-${index}`} className="max-w-full rounded-full bg-slate-50 px-3 py-1.5 text-xs text-slate-500 ring-1 ring-slate-100">{item}</span>)}</div> : null}
+                      </div>
                     ) : <p className="mt-4 rounded-2xl border border-dashed border-slate-200 p-5 text-sm text-slate-400">尚未生成路线图。生成后将保存阶段拆解、风险与周期建议，但不会自动创建任务。</p>}
                   </div>
                 ) : null}

--- a/src/components/LogPage.tsx
+++ b/src/components/LogPage.tsx
@@ -1,9 +1,10 @@
 import { useMemo, useState, type ReactNode } from 'react';
-import type { Achievement, AIArtifact, AIArtifactInput, Goal, PressureBreakdown, PressureHistoryRecord, Task, UserProfile } from '../types/task';
+import type { Achievement, AIArtifact, AIArtifactInput, Goal, PressureBreakdown, PressureHistoryRecord, Task, TaskInput, UserProfile } from '../types/task';
 import { calculateAverageCompletionLeadHours, calculateAverageDailyPressure, calculateAverageImportance, calculateCategoryDistribution, calculateCompletionRate, calculateConsecutiveUsageDays, calculateDailyCompletionHeatmap, calculateDeadlineSurvivalRatio, calculateGoalProgress, calculateLastMinuteCompletionRatio, countAbandonedTasks, countCompletedTasks, countOverdueTasks, getCurrentLifeFocus, getLatestAIInsight } from '../lib/analytics/lifeStats';
 import { analyzeBehavior } from '../lib/behavior/behaviorAnalytics';
 import { calculateBMI, getHealthReadiness } from '../lib/health/healthMetrics';
 import { buildPressureHistogram, calculateContinuousOverloadDays, calculateOverloadFrequency, calculatePressureVolatility, calculateRecoverySpeed, getPressureInsight } from '../lib/pressure/pressureAnalytics';
+import { parseTaskIntakeResponse } from '../services/taskIntakePrompt';
 import { getActivityTypeLabel } from '../utils/taskScoring';
 import { ActivityLog } from './ActivityLog';
 import { AIReviewPanel } from './AIReviewPanel';
@@ -58,8 +59,48 @@ function getPressureMood(pressure: number): string {
   return '平稳：系统暂时有余裕。';
 }
 
+function formatDeadline(deadline?: string): string {
+  if (!deadline) return '未设置';
+  const date = new Date(deadline);
+  if (Number.isNaN(date.getTime())) return '未设置';
+  return new Intl.DateTimeFormat('zh-CN', { dateStyle: 'medium', timeStyle: 'short' }).format(date);
+}
+
+function getTaskIntakeDrafts(artifact: AIArtifact): { drafts?: TaskInput[]; notes?: string; error?: string } {
+  try {
+    const result = parseTaskIntakeResponse(artifact.content);
+    return { drafts: result.tasks, notes: result.notes };
+  } catch {
+    return { error: '草稿解析失败，请重新生成' };
+  }
+}
+
+function getAIArtifactSummary(artifact: AIArtifact): string {
+  if (artifact.kind !== 'task-intake') return `${artifact.content.slice(0, 180)}${artifact.content.length > 180 ? '…' : ''}`;
+  const result = getTaskIntakeDrafts(artifact);
+  if (result.error) return result.error;
+  if (!result.drafts?.length) return result.notes || '没有识别到明确任务。';
+  return `整理出 ${result.drafts.length} 个任务草稿：${result.drafts.slice(0, 3).map((draft) => draft.title).join('、')}${result.drafts.length > 3 ? '…' : ''}`;
+}
+
+function AIArtifactCard({ artifact }: { artifact: AIArtifact }) {
+  const taskIntakeResult = artifact.kind === 'task-intake' ? getTaskIntakeDrafts(artifact) : undefined;
+  return <article className="rounded-3xl bg-white/75 p-4 ring-1 ring-white/80">
+    <div className="flex flex-wrap items-center justify-between gap-2"><h3 className="font-semibold text-slate-950">{artifact.title}</h3><time className="text-xs text-slate-400">{formatTime(artifact.createdAt)}</time></div>
+    {taskIntakeResult ? taskIntakeResult.error ? <p className="mt-3 rounded-2xl bg-rose-50 px-3 py-2 text-sm font-semibold text-rose-600 ring-1 ring-rose-100">{taskIntakeResult.error}</p> : <div className="mt-3 grid gap-3 md:grid-cols-2">
+      {taskIntakeResult.notes ? <p className="text-sm leading-6 text-slate-500 md:col-span-2">{taskIntakeResult.notes}</p> : null}
+      {taskIntakeResult.drafts?.length ? taskIntakeResult.drafts.map((draft, index) => <section key={`${draft.title}-${index}`} className="min-w-0 rounded-2xl bg-slate-50/80 p-3 ring-1 ring-slate-100">
+        <h4 className="font-semibold text-slate-900">{draft.title}</h4>
+        {draft.description ? <p className="mt-2 text-sm leading-6 text-slate-500">{draft.description}</p> : null}
+        <div className="mt-3 flex flex-wrap gap-2 text-xs font-semibold text-slate-500"><span className="rounded-full bg-white px-2.5 py-1 ring-1 ring-slate-100">重要性 {draft.importance}/10</span><span className="rounded-full bg-white px-2.5 py-1 ring-1 ring-slate-100">截止 {formatDeadline(draft.deadline)}</span></div>
+        {draft.decomposition?.length ? <div className="mt-3"><p className="text-xs font-semibold text-slate-500">拆解步骤</p><ul className="mt-1 space-y-1 text-xs leading-5 text-slate-500">{draft.decomposition.slice(0, 5).map((item) => <li key={item}>· {item}</li>)}</ul></div> : null}
+      </section>) : <p className="rounded-2xl border border-dashed border-slate-200 p-4 text-sm text-slate-400 md:col-span-2">没有识别到明确任务。</p>}
+    </div> : <p className="mt-2 whitespace-pre-wrap text-sm leading-6 text-slate-500">{artifact.content.slice(0, 360)}{artifact.content.length > 360 ? '…' : ''}</p>}
+  </article>;
+}
+
 function buildTimelineEvents(tasks: Task[], pressureHistory: PressureHistoryRecord[], achievements: Achievement[], aiArtifacts: AIArtifact[]): TimelineEvent[] {
-  const aiEvents: TimelineEvent[] = aiArtifacts.map((artifact) => ({ id: `ai-${artifact.id}`, timestamp: artifact.createdAt, type: 'ai', title: artifact.title, body: `${artifact.content.slice(0, 180)}${artifact.content.length > 180 ? '…' : ''}`, tone: artifact.kind === 'goal-roadmap' ? 'bg-violet-50 text-violet-700 ring-violet-100' : 'bg-sky-50 text-sky-700 ring-sky-100' }));
+  const aiEvents: TimelineEvent[] = aiArtifacts.map((artifact) => ({ id: `ai-${artifact.id}`, timestamp: artifact.createdAt, type: 'ai', title: artifact.title, body: getAIArtifactSummary(artifact), tone: artifact.kind === 'goal-roadmap' ? 'bg-violet-50 text-violet-700 ring-violet-100' : 'bg-sky-50 text-sky-700 ring-sky-100' }));
   const pressureEvents: TimelineEvent[] = pressureHistory.flatMap((record) => {
     const events: TimelineEvent[] = [];
     if (record.eventType === 'recalibration') events.push({ id: `pressure-recalibration-${record.id}`, timestamp: record.timestamp, type: 'pressure', title: '压力重新校准', body: record.note || `压力映射被重新写入，当前指数 ${record.pressure}。`, tone: 'bg-slate-50 text-slate-700 ring-slate-100' });
@@ -137,6 +178,6 @@ export function LogPage({ tasks, goals, profile, pressure, pressureHistory, achi
 
     {activeTab === 'trends' ? <section className="space-y-6"><SectionShell eyebrow="长期视角" title="长期趋势系统"><div className="grid gap-5 lg:grid-cols-[1.2fr_0.8fr]"><TinyBars values={pressureHistory.slice(-36).map((record) => record.pressure)} /><div className="space-y-3"><StatCard label="本月高压天数" value={calculateContinuousOverloadDays(pressureHistory)} detail="当前连续样本，未来扩展为月度统计。" /><StatCard label="执行演化" value={behavior.executionConsistency} detail="过去行为形成的稳定性判断。" /></div></div><p className="mt-5 text-sm leading-7 text-slate-500">这里将扩展为月度演化、季节性变化、年度回顾、习惯一致性、压力演化、执行演化与健康演化。</p></SectionShell></section> : null}
 
-    {activeTab === 'ai' ? <section className="space-y-6"><SectionShell eyebrow="AI 洞察" title="第三人称行为观察"><p className="text-sm leading-7 text-slate-500">AI 不负责鼓励你。它负责观察：压力模式、行为倾向、恢复速度、长期任务稳定性、风险和节奏建议。</p><div className="mt-5 grid gap-3">{aiArtifacts.slice(0, 8).map((artifact) => <article key={artifact.id} className="rounded-3xl bg-white/75 p-4 ring-1 ring-white/80"><div className="flex flex-wrap items-center justify-between gap-2"><h3 className="font-semibold text-slate-950">{artifact.title}</h3><time className="text-xs text-slate-400">{formatTime(artifact.createdAt)}</time></div><p className="mt-2 whitespace-pre-wrap text-sm leading-6 text-slate-500">{artifact.content.slice(0, 360)}{artifact.content.length > 360 ? '…' : ''}</p></article>)}</div></SectionShell><AIReviewPanel tasks={tasks} pressureHistory={pressureHistory} onAIReportGenerated={onAIReportGenerated} /></section> : null}
+    {activeTab === 'ai' ? <section className="space-y-6"><SectionShell eyebrow="AI 洞察" title="第三人称行为观察"><p className="text-sm leading-7 text-slate-500">AI 不负责鼓励你。它负责观察：压力模式、行为倾向、恢复速度、长期任务稳定性、风险和节奏建议。</p><div className="mt-5 grid gap-3">{aiArtifacts.length ? aiArtifacts.slice(0, 8).map((artifact) => <AIArtifactCard key={artifact.id} artifact={artifact} />) : <div className="rounded-3xl border border-dashed border-slate-200 bg-white/65 p-8 text-center text-sm text-slate-400">尚未生成 AI 洞察。完成一次任务整理或行为分析后，这里会展示可读摘要。</div>}</div></SectionShell><AIReviewPanel tasks={tasks} pressureHistory={pressureHistory} onAIReportGenerated={onAIReportGenerated} /></section> : null}
   </section>;
 }

--- a/src/services/goals/roadmapPrompt.ts
+++ b/src/services/goals/roadmapPrompt.ts
@@ -14,7 +14,7 @@ Rules:
 
 Return JSON shape:
 {
-  "stages": ["阶段建议，含阶段目标与顺序"],
+  "stages": [{ "title": "阶段名", "timeRange": "时间范围", "coreAction": "一句话核心行动" }],
   "milestones": ["关键里程碑，含可验证结果"],
   "weeklyMonthlyDirection": ["每周或每月推进方向"],
   "risks": ["风险与规避建议"],
@@ -59,6 +59,19 @@ function toStringList(value: unknown): string[] {
   return value.filter((item): item is string => typeof item === 'string' && Boolean(item.trim())).map((item) => item.trim());
 }
 
+function toStageList(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((item) => {
+    if (typeof item === 'string' && item.trim()) return [item.trim()];
+    if (!item || typeof item !== 'object') return [];
+    const stage = item as Record<string, unknown>;
+    const title = typeof stage.title === 'string' ? stage.title.trim() : '';
+    const timeRange = typeof stage.timeRange === 'string' ? stage.timeRange.trim() : '';
+    const coreAction = typeof stage.coreAction === 'string' ? stage.coreAction.trim() : '';
+    return title || coreAction ? [`${title || '未命名阶段'}｜${timeRange || '时间范围待确认'}｜${coreAction || title}`] : [];
+  });
+}
+
 function addSection(items: string[], title: string, values: string[]): void {
   values.slice(0, 6).forEach((value) => items.push(`${title}：${value}`));
 }
@@ -74,7 +87,7 @@ export function parseGoalRoadmapResponse(content: string): { roadmapSuggestions:
   if (!parsed || typeof parsed !== 'object') throw new Error('AI 返回 JSON 结构无效。');
   const payload = parsed as { stages?: unknown; milestones?: unknown; weeklyMonthlyDirection?: unknown; risks?: unknown; firstActions?: unknown; roadmapSuggestions?: unknown; notes?: unknown };
   const roadmapSuggestions: string[] = [];
-  addSection(roadmapSuggestions, '阶段', toStringList(payload.stages));
+  addSection(roadmapSuggestions, '阶段', toStageList(payload.stages));
   addSection(roadmapSuggestions, '里程碑', toStringList(payload.milestones));
   addSection(roadmapSuggestions, '周/月方向', toStringList(payload.weeklyMonthlyDirection));
   addSection(roadmapSuggestions, '风险', toStringList(payload.risks));


### PR DESCRIPTION
### Motivation
- 减少界面中对原始 JSON 与浏览器本地日期格式的直观暴露，提升长期目标与 AI 洞察的可读性。 
- 把 AI 生成的多行文本路线图转为更简约的节点/时间线展示，便于用户快速扫描并按需展开细节。 
- 在数据页对 AI 返回的任务草稿进行安全解析并以卡片形式展示，而非直接回显原始 JSON。 

### Description
- 将长期目标表单的空日期显示改为中文占位层（`选择日期`），保留原有 `input type="date"` 交互但避免裸露浏览器默认格式；变更位于 `src/components/GoalRoadmapPanel.tsx`。 
- 把路线图展示从简单的多行文本列表替换为节点式 timeline 结构；每个节点包含阶段名、时间范围、一句话核心行动与折叠后展开的详情，视觉与交互保持极简风格并复用现有 `roadmapSuggestions` 存储，修改位于 `src/components/GoalRoadmapPanel.tsx` 与解析兼容逻辑的 `src/services/goals/roadmapPrompt.ts`。 
- 增加对 AI 路线图结构化返回的兼容解析（接受对象或字符串形式的阶段条目），通过 `toStageList` 等函数将结构化阶段转换为当前展示列表而不改数据库结构，位于 `src/services/goals/roadmapPrompt.ts`。 
- 移除面向用户的“复制 JSON”按钮并停止在 UI 中直接展示 `task-intake` 的原始 JSON，改为在 `Data > AI 洞察` 中先尝试 `parseTaskIntakeResponse` 解析再渲染为用户友好的摘要卡片（标题、描述、重要性、截止时间、拆解步骤），相关改动在 `src/components/AITaskCommandBar.tsx`（隐藏复制入口）和 `src/components/LogPage.tsx`（卡片渲染与安全失败提示）。 
- 解析失败时只显示安全提示“草稿解析失败，请重新生成”，并在 AI 洞察页补充空状态文案，避免把 AI 原始文本暴露给正式 UI。 

### Testing
- 运行构建：已执行 `npm run build` 且构建通过（生成 production bundle）。 
- 静态检查：已确认 `git diff --check` / `rg` 检索未留下裸露 `dd/mm/yyyy` 占位或用户可见 JSON 复制入口。 
- 运行时 smoke test：启动本地 dev server 并通过 `curl http://127.0.0.1:5173/` 与 `curl http://127.0.0.1:5173/src/main.tsx` 验证应用可响应。 
- 自动化浏览器截图不可用：容器中未安装 Chromium/Playwright/Puppeteer，因而未进行浏览器端截图，但所有变更通过构建与 HTTP smoke checks 验证。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c2c84d1bc832cb30984dac3c23cfa)