### PR TITLE
Sync social graph, refine pressure-history derivation, and add completedAt + UI improvements

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,7 +32,7 @@ import {
   normalizeLifecycleStatus,
   normalizeProgressMode,
 } from './utils/taskScoring';
-import { appendPressureHistoryRecord, createPressureHistoryRecord, normalizePressureHistory } from './utils/pressureHistory';
+import { appendPressureHistoryRecord, createPressureHistoryRecord, normalizePressureHistory, replaceTaskDerivedPressureHistory } from './utils/pressureHistory';
 import { sortActiveTasksByProgress } from './utils/taskDerivedState';
 import { loadCloudData, saveCloudGoals, saveCloudPressureHistory, saveCloudProfile, saveCloudTasks } from './lib/cloudSync';
 import { hasValue, loadValue, savePressure, saveTasks, saveValue, storageKeys } from './storage';
@@ -134,6 +134,7 @@ function normalizeTaskInput(input: TaskInput): TaskInput {
     linkedGoalIds: input.linkedGoalIds?.filter(Boolean),
     activityType: normalizeActivityType(input.activityType),
     lifecycleStatus,
+    completedAt: lifecycleStatus === 'completed' ? input.completedAt : undefined,
   };
 }
 
@@ -362,6 +363,8 @@ function App() {
   const [achievements, setAchievements] = useLocalStorage<Achievement[]>(storageKeys.achievements, []);
   const [aiArtifacts, setAIArtifacts] = useLocalStorage<AIArtifact[]>(storageKeys.aiArtifacts, []);
   const [profile, setProfile] = useLocalStorage<UserProfile>(storageKeys.profile, defaultProfile);
+  const [socialNodes, setSocialNodes] = useLocalStorage<unknown[]>(storageKeys.socialNodes, []);
+  const [socialLayoutVersion, setSocialLayoutVersion] = useLocalStorage<number>(storageKeys.socialLayoutVersion, 0);
   const [onboardingComplete, setOnboardingComplete] = useLocalStorage<boolean>(storageKeys.onboardingComplete, readInitialOnboardingComplete());
   const legacyReferencePressure = readBaselinePressure() ?? 35;
   const [pressureCalibration, setPressureCalibration] = useLocalStorage<PressureCalibrationSnapshot>(storageKeys.pressureCalibration, normalizePressureCalibration(null, legacyReferencePressure));
@@ -417,9 +420,13 @@ function App() {
         const mergedTasks = mergeById(normalizedTasks, cloudData.tasks);
         const mergedGoals = mergeById(normalizedGoals, cloudData.goals);
         const mergedPressureHistory = mergeById(normalizedPressureHistory, cloudData.pressureHistory);
+        const mergedSocialNodes = cloudData.socialNodes ?? socialNodes;
+        const mergedSocialLayoutVersion = cloudData.socialLayoutVersion ?? socialLayoutVersion;
         setTasks(mergedTasks);
         setGoals(mergedGoals);
         setPressureHistory(mergedPressureHistory);
+        setSocialNodes(mergedSocialNodes);
+        setSocialLayoutVersion(mergedSocialLayoutVersion);
         if (cloudData.profile) setProfile(cloudData.profile);
         if (cloudData.pressureCalibration) setPressureCalibration(cloudData.pressureCalibration);
         if (cloudData.onboardingComplete !== null) setOnboardingComplete(cloudData.onboardingComplete);
@@ -432,6 +439,8 @@ function App() {
             profile: cloudData.profile ?? normalizedProfile,
             pressureCalibration: cloudData.pressureCalibration ?? normalizedPressureCalibration,
             onboardingComplete: cloudData.onboardingComplete ?? onboardingComplete,
+            socialNodes: mergedSocialNodes,
+            socialLayoutVersion: mergedSocialLayoutVersion,
           }, session),
         ]);
         setCloudStatus('已同步到云端');
@@ -470,10 +479,10 @@ function App() {
 
   useEffect(() => {
     if (!session || !isCloudReady || isApplyingCloudData.current) return;
-    saveCloudProfile({ profile: normalizedProfile, pressureCalibration: normalizedPressureCalibration, onboardingComplete }, session)
+    saveCloudProfile({ profile: normalizedProfile, pressureCalibration: normalizedPressureCalibration, onboardingComplete, socialNodes, socialLayoutVersion }, session)
       .then(() => setCloudStatus('已同步到云端'))
       .catch((error) => setCloudError(error instanceof Error ? error.message : '个人设置云同步失败。'));
-  }, [isCloudReady, normalizedPressureCalibration, normalizedProfile, onboardingComplete, session]);
+  }, [isCloudReady, normalizedPressureCalibration, normalizedProfile, onboardingComplete, session, socialLayoutVersion, socialNodes]);
 
   useEffect(() => {
     const intervalId = window.setInterval(() => setPressureClock(Date.now()), 60 * 1000);
@@ -604,6 +613,13 @@ function App() {
     const snapshotPressure = calculatePressureIndex(sourceTasks, calibration, legacyReferencePressure);
     const record = createPressureHistoryRecord(snapshotPressure, sourceTasks, eventType, note);
     setPressureHistory((records) => appendPressureHistoryRecord(records, record));
+  }
+
+  function recalculateTaskDerivedPressureHistory(sourceTasks = normalizedTasks, note = '根据当前任务重算压力曲线，已清理可识别的任务推导点。') {
+    const snapshotPressure = calculatePressureIndex(sourceTasks, normalizedPressureCalibration, legacyReferencePressure);
+    const record = createPressureHistoryRecord(snapshotPressure, sourceTasks, 'auto', note, new Date(), 'task_derived');
+    setPressureHistory((records) => replaceTaskDerivedPressureHistory(records, record));
+    setCloudToast('已重算任务推导压力点；手动记录和未标记老数据已保留。');
   }
 
   useEffect(() => {
@@ -790,14 +806,13 @@ function App() {
         return {
           ...task,
           ...normalizedInput,
-          completedAt: normalizedInput.lifecycleStatus === 'completed' ? task.completedAt ?? now : lifecycleChanged ? undefined : task.completedAt,
+          completedAt: normalizedInput.lifecycleStatus === 'completed' ? normalizedInput.completedAt || task.completedAt || now : undefined,
           abandonedAt: normalizedInput.lifecycleStatus === 'abandoned' ? task.abandonedAt ?? now : lifecycleChanged ? undefined : task.abandonedAt,
           updatedAt: now,
         };
       });
       setTasks(nextTasks);
-      if (editingTask.lifecycleStatus !== normalizedInput.lifecycleStatus && normalizedInput.lifecycleStatus === 'completed') recordPressureSnapshot('task_completed', nextTasks, `完成任务：${normalizedInput.title}`);
-      if (editingTask.lifecycleStatus !== normalizedInput.lifecycleStatus && normalizedInput.lifecycleStatus === 'abandoned') recordPressureSnapshot('task_abandoned', nextTasks, `放弃任务：${normalizedInput.title}`);
+      recalculateTaskDerivedPressureHistory(nextTasks, `修改任务后重算压力曲线：${normalizedInput.title}`);
     } else {
       const newTask = createTask(normalizedInput);
       const nextTasks = [newTask, ...normalizedTasks];
@@ -834,16 +849,23 @@ function App() {
         : item,
     );
     setTasks(nextTasks);
-    recordPressureSnapshot(lifecycleStatus === 'completed' ? 'task_completed' : 'task_abandoned', nextTasks, `${lifecycleStatus === 'completed' ? '完成' : '放弃'}任务：${task.title}`);
+    recalculateTaskDerivedPressureHistory(nextTasks, `${lifecycleStatus === 'completed' ? '完成' : '放弃'}任务后重算压力曲线：${task.title}`);
   }
 
   function deleteTask(taskId: string) {
     const deletedTask = normalizedTasks.find((task) => task.id === taskId);
     const nextTasks = normalizedTasks.filter((task) => task.id !== taskId);
     setTasks(nextTasks);
-    recordPressureSnapshot('manual', nextTasks, deletedTask ? `删除任务：${deletedTask.title}` : '删除任务');
+    recalculateTaskDerivedPressureHistory(nextTasks, deletedTask ? `删除任务后重算压力曲线：${deletedTask.title}` : '删除任务后重算压力曲线');
   }
 
+
+  function restoreTask(task: Task) {
+    const now = new Date().toISOString();
+    const nextTasks = normalizedTasks.map((item) => item.id === task.id ? { ...item, lifecycleStatus: 'active' as const, progress: item.progress >= 100 ? 0 : item.progress, taskProgress: (item.taskProgress ?? item.progress) >= 100 ? 0 : item.taskProgress, completedAt: undefined, abandonedAt: undefined, updatedAt: now } : item);
+    setTasks(nextTasks);
+    recalculateTaskDerivedPressureHistory(nextTasks, `恢复任务后重算压力曲线：${task.title}`);
+  }
 
   function updateReviewNote(taskId: string, reviewNote: string) {
     const now = new Date().toISOString();
@@ -937,8 +959,8 @@ function App() {
     home: <HomePage pressure={pressure} pressureHistory={normalizedPressureHistory} recommendedTasks={recommendedTasks} activeTasks={activeTasks} onRecalibrate={openRecalibration} onOpenTasks={() => setActiveModule('task')} />,
     task: taskModule,
     map: <LifeMapPage goals={normalizedGoals} tasks={normalizedTasks} onSaveGoal={saveGoal} onDeleteGoal={deleteGoal} onRoadmapGenerated={(artifact) => { saveAIArtifact(artifact); unlockAchievement('roadmap-generated'); }} />,
-    social: <SocialPage />,
-    log: <LogPage tasks={normalizedTasks} goals={normalizedGoals} profile={normalizedProfile} pressure={pressure} pressureHistory={normalizedPressureHistory} achievements={normalizedAchievements} aiArtifacts={normalizedAIArtifacts} onAIReportGenerated={(artifact) => { saveAIArtifact(artifact); unlockAchievement('ai-report-generated'); }} onDelete={deleteTask} onReviewNoteChange={updateReviewNote} />,
+    social: <SocialPage storedNodes={socialNodes} setStoredNodes={setSocialNodes} layoutVersion={socialLayoutVersion} setLayoutVersion={setSocialLayoutVersion} />,
+    log: <LogPage tasks={normalizedTasks} goals={normalizedGoals} profile={normalizedProfile} pressure={pressure} pressureHistory={normalizedPressureHistory} achievements={normalizedAchievements} aiArtifacts={normalizedAIArtifacts} onRecalculatePressureHistory={() => recalculateTaskDerivedPressureHistory()} onAIReportGenerated={(artifact) => { saveAIArtifact(artifact); unlockAchievement('ai-report-generated'); }} onDelete={deleteTask} onEdit={startEditing} onRestore={restoreTask} onReviewNoteChange={updateReviewNote} />,
     me: <ProfilePage profile={normalizedProfile} onProfileChange={setProfile} isEmailVerified={Boolean(session?.user.email_confirmed_at)} />,
   };
 

--- a/src/components/AITaskCommandBar.tsx
+++ b/src/components/AITaskCommandBar.tsx
@@ -29,7 +29,6 @@ export function AITaskCommandBar({ tasks, onConfirmTasks, onAIArtifactGenerated 
   const [state, setState] = useState<IntakeState>('idle');
   const [drafts, setDrafts] = useState<TaskInput[]>([]);
   const [notes, setNotes] = useState('');
-  const [rawJson, setRawJson] = useState('');
   const [errorMessage, setErrorMessage] = useState('');
   const [canResetAuthState, setCanResetAuthState] = useState(false);
 
@@ -48,7 +47,6 @@ export function AITaskCommandBar({ tasks, onConfirmTasks, onAIArtifactGenerated 
     setCanResetAuthState(false);
     setDrafts([]);
     setNotes('');
-    setRawJson('');
     try {
       const payload = createTaskIntakePayload(trimmedInput, tasks);
       const taskContext = tasks
@@ -66,7 +64,6 @@ export function AITaskCommandBar({ tasks, onConfirmTasks, onAIArtifactGenerated 
       const parsed = parseTaskIntakeResponse(result);
       setDrafts(parsed.tasks);
       setNotes(parsed.notes);
-      setRawJson(parsed.rawJson);
       setState('ready');
       onAIArtifactGenerated?.({
         kind: 'task-intake',
@@ -90,7 +87,6 @@ export function AITaskCommandBar({ tasks, onConfirmTasks, onAIArtifactGenerated 
     setInput('');
     setDrafts([]);
     setNotes('');
-    setRawJson('');
     setCanResetAuthState(false);
     setState('idle');
   }
@@ -98,7 +94,6 @@ export function AITaskCommandBar({ tasks, onConfirmTasks, onAIArtifactGenerated 
   function cancelDrafts() {
     setDrafts([]);
     setNotes('');
-    setRawJson('');
     setErrorMessage('');
     setCanResetAuthState(false);
     setState('idle');
@@ -108,11 +103,6 @@ export function AITaskCommandBar({ tasks, onConfirmTasks, onAIArtifactGenerated 
     await resetCloudAIAuthState();
     setCanResetAuthState(false);
     setErrorMessage('已清除登录缓存。请重新登录后再使用 VD Cloud AI。');
-  }
-
-  async function copyJson() {
-    if (!rawJson || !navigator.clipboard) return;
-    await navigator.clipboard.writeText(rawJson);
   }
 
   return (
@@ -153,7 +143,6 @@ export function AITaskCommandBar({ tasks, onConfirmTasks, onAIArtifactGenerated 
               <h3 className="text-lg font-semibold">待确认任务草稿</h3>
               {notes ? <p className="mt-1 text-sm text-slate-500">{notes}</p> : null}
             </div>
-            {rawJson ? <button type="button" onClick={copyJson} className="rounded-full bg-slate-100 px-3 py-1.5 text-xs font-semibold text-slate-500 hover:bg-slate-200">复制 JSON</button> : null}
           </div>
           {drafts.length === 0 ? (
             <div className="mt-4 rounded-2xl border border-dashed border-slate-200 p-5 text-center text-sm text-slate-400">没有识别到明确任务。</div>

--- a/src/components/ActivityLog.tsx
+++ b/src/components/ActivityLog.tsx
@@ -7,6 +7,8 @@ interface ActivityLogProps {
   limit?: number;
   title?: string;
   onDelete?: (taskId: string) => void;
+  onEdit?: (task: Task) => void;
+  onRestore?: (task: Task) => void;
   onReviewNoteChange?: (taskId: string, reviewNote: string) => void;
 }
 
@@ -60,7 +62,7 @@ function groupTasks(tasks: Task[], limit: number): ArchiveGroup[] {
 
 // Future review module hook: these archive groups can be reused as selectable daily,
 // weekly, monthly, or manual log context for AI-assisted reflection. No AI/API is called in v0.6.3.
-export function ActivityLog({ tasks, limit = Number.POSITIVE_INFINITY, title = '归档日志', onDelete, onReviewNoteChange }: ActivityLogProps) {
+export function ActivityLog({ tasks, limit = Number.POSITIVE_INFINITY, title = '归档日志', onDelete, onEdit, onRestore, onReviewNoteChange }: ActivityLogProps) {
   const [expandedTaskId, setExpandedTaskId] = useState<string | undefined>();
   const [openGroups, setOpenGroups] = useState<Record<string, boolean>>({ today: true });
   const archivedTasks = tasks.filter((task) => task.lifecycleStatus === 'completed' || task.lifecycleStatus === 'abandoned').sort((a, b) => logDate(b).getTime() - logDate(a).getTime());
@@ -76,7 +78,7 @@ export function ActivityLog({ tasks, limit = Number.POSITIVE_INFINITY, title = '
     const isExpanded = expandedTaskId === task.id;
     return (
       <li key={task.id} className="rounded-3xl bg-slate-50/80 p-4 ring-1 ring-white/80">
-        <div className="flex flex-wrap items-center justify-between gap-3"><h3 className="font-medium text-slate-900">{task.title}</h3><div className="flex flex-wrap items-center gap-2"><span className="rounded-full bg-white px-2.5 py-1 text-xs font-medium text-slate-500">{getLifecycleStatusLabel(task.lifecycleStatus)}</span><button type="button" onClick={() => setExpandedTaskId(isExpanded ? undefined : task.id)} className="rounded-full bg-white px-2.5 py-1 text-xs font-semibold text-slate-500 shadow-sm hover:bg-slate-100">{isExpanded ? '收起' : '详情'}</button>{onDelete ? <button type="button" onClick={() => confirmDelete(task)} className="rounded-full bg-white px-2.5 py-1 text-xs font-semibold text-rose-500 shadow-sm hover:bg-rose-50">删除</button> : null}</div></div>
+        <div className="flex flex-wrap items-center justify-between gap-3"><h3 className="font-medium text-slate-900">{task.title}</h3><div className="flex flex-wrap items-center gap-2"><span className="rounded-full bg-white px-2.5 py-1 text-xs font-medium text-slate-500">{getLifecycleStatusLabel(task.lifecycleStatus)}</span><button type="button" onClick={() => setExpandedTaskId(isExpanded ? undefined : task.id)} className="rounded-full bg-white px-2.5 py-1 text-xs font-semibold text-slate-500 shadow-sm hover:bg-slate-100">{isExpanded ? '收起' : '详情'}</button>{onEdit ? <button type="button" onClick={() => onEdit(task)} className="rounded-full bg-white px-2.5 py-1 text-xs font-semibold text-slate-600 shadow-sm hover:bg-slate-100">编辑</button> : null}{onRestore ? <button type="button" onClick={() => onRestore(task)} className="rounded-full bg-white px-2.5 py-1 text-xs font-semibold text-sky-600 shadow-sm hover:bg-sky-50">恢复为未完成</button> : null}{onDelete ? <button type="button" onClick={() => confirmDelete(task)} className="rounded-full bg-white px-2.5 py-1 text-xs font-semibold text-rose-500 shadow-sm hover:bg-rose-50">删除</button> : null}</div></div>
         <div className="mt-3 flex flex-wrap gap-2 text-xs text-slate-500"><span className="rounded-full bg-white px-2.5 py-1">{getActivityTypeLabel(task.activityType)}</span><span className="rounded-full bg-white px-2.5 py-1">{formatLogTime(time)}</span></div>
         {task.reviewNote && !isExpanded ? <p className="mt-3 line-clamp-2 text-xs leading-5 text-slate-500">{task.reviewNote}</p> : null}
         {isExpanded ? <div className="mt-4 rounded-3xl bg-white/70 p-4 ring-1 ring-white/80"><label className="text-sm font-semibold text-slate-600" htmlFor={`review-note-${task.id}`}>数据记录</label><textarea id={`review-note-${task.id}`} value={task.reviewNote ?? ''} onChange={(event) => onReviewNoteChange?.(task.id, event.target.value)} className="mt-2 min-h-24 w-full rounded-2xl border border-slate-200/80 bg-white/90 px-4 py-3 text-sm outline-none transition focus:border-sky-200 focus:ring-4 focus:ring-sky-100/70" placeholder="写下这次完成或放弃后的观察。" /></div> : null}

--- a/src/components/GoalRoadmapPanel.tsx
+++ b/src/components/GoalRoadmapPanel.tsx
@@ -19,6 +19,7 @@ const categories = ['study', 'research', 'fitness', 'work', 'life', 'social', 'o
 const roadmapFacets = ['AI 路线图', '阶段拆解', '风险分析', '周期建议'] as const;
 
 type RoadmapState = { loadingGoalId?: string; errorGoalId?: string; message?: string };
+type RoadmapNode = { id: string; title: string; timeRange: string; summary: string; details: string[] };
 
 function createGoalInput(goal: Goal): GoalInput {
   return {
@@ -31,8 +32,39 @@ function createGoalInput(goal: Goal): GoalInput {
   };
 }
 
-function getPreviewItems(goal: Goal) {
-  return goal.roadmapSuggestions?.slice(0, 2) ?? [];
+function splitSuggestion(item: string): { section: string; content: string } {
+  const separatorIndex = item.indexOf('：');
+  if (separatorIndex < 0) return { section: '阶段', content: item.trim() };
+  return { section: item.slice(0, separatorIndex).trim(), content: item.slice(separatorIndex + 1).trim() };
+}
+
+function getRoadmapNodes(goal: Goal): RoadmapNode[] {
+  const suggestions = goal.roadmapSuggestions ?? [];
+  const grouped = suggestions.reduce<Record<string, string[]>>((result, item) => {
+    const { section, content } = splitSuggestion(item);
+    (result[section] ??= []).push(content);
+    return result;
+  }, {});
+  const stages = grouped['阶段']?.length ? grouped['阶段'] : suggestions.slice(0, 4);
+  return stages.map((stage, index) => {
+    const [rawTitle, rawTimeRange, rawSummary] = stage.split('｜').map((item) => item.trim());
+    const summary = rawSummary || rawTitle || `推进阶段 ${index + 1}`;
+    return {
+      id: `${goal.id}-stage-${index}`,
+      title: rawSummary ? rawTitle : `阶段 ${index + 1}`,
+      timeRange: rawTimeRange || '时间范围待确认',
+      summary,
+      details: [
+        grouped['里程碑']?.[index] ? `里程碑：${grouped['里程碑'][index]}` : undefined,
+        grouped['周/月方向']?.[index] ? `推进节奏：${grouped['周/月方向'][index]}` : undefined,
+        index === 0 && grouped['第一步行动']?.[0] ? `第一步：${grouped['第一步行动'][0]}` : undefined,
+      ].filter((item): item is string => Boolean(item)),
+    };
+  });
+}
+
+function getRoadmapNotes(goal: Goal): string[] {
+  return (goal.roadmapSuggestions ?? []).filter((item) => splitSuggestion(item).section !== '阶段');
 }
 
 export function GoalRoadmapPanel({ goals, tasks, onSaveGoal, onDeleteGoal, onRoadmapGenerated }: GoalRoadmapPanelProps) {
@@ -45,7 +77,12 @@ export function GoalRoadmapPanel({ goals, tasks, onSaveGoal, onDeleteGoal, onRoa
   const [editingGoalId, setEditingGoalId] = useState<string | undefined>();
   const [expandedGoalId, setExpandedGoalId] = useState<string | undefined>();
   const [roadmapState, setRoadmapState] = useState<RoadmapState>({});
+  const [expandedNodeIds, setExpandedNodeIds] = useState<string[]>([]);
   const isEditing = Boolean(editingGoalId);
+
+  function toggleNode(nodeId: string) {
+    setExpandedNodeIds((current) => current.includes(nodeId) ? current.filter((id) => id !== nodeId) : [...current, nodeId]);
+  }
 
   useEffect(() => {
     if (expandedGoalId && !goals.some((goal) => goal.id === expandedGoalId)) setExpandedGoalId(undefined);
@@ -141,7 +178,10 @@ export function GoalRoadmapPanel({ goals, tasks, onSaveGoal, onDeleteGoal, onRoa
         </label>
         <label className="space-y-2 text-xs font-semibold text-slate-400">
           时间跨度
-          <input type="date" value={targetDate} onChange={(event) => setTargetDate(event.target.value)} className="w-full rounded-2xl border border-transparent bg-white/85 px-4 py-3 text-sm text-slate-700 outline-none transition focus:border-sky-100 focus:ring-4 focus:ring-sky-100/60" />
+          <span className="relative block">
+            {!targetDate ? <span className="pointer-events-none absolute inset-y-0 left-4 flex items-center text-sm font-normal text-slate-400">选择日期</span> : null}
+            <input aria-label="截止日期" type="date" value={targetDate} onChange={(event) => setTargetDate(event.target.value)} className={`w-full rounded-2xl border border-transparent bg-white/85 px-4 py-3 text-sm outline-none transition focus:border-sky-100 focus:ring-4 focus:ring-sky-100/60 ${targetDate ? 'text-slate-700' : 'text-transparent'}`} />
+          </span>
         </label>
         <label className="space-y-2 text-xs font-semibold text-slate-400">
           领域
@@ -164,7 +204,8 @@ export function GoalRoadmapPanel({ goals, tasks, onSaveGoal, onDeleteGoal, onRoa
           {goals.map((goal) => {
             const isExpanded = expandedGoalId === goal.id;
             const isLoading = roadmapState.loadingGoalId === goal.id;
-            const previewItems = getPreviewItems(goal);
+            const roadmapNodes = getRoadmapNodes(goal);
+            const roadmapNotes = getRoadmapNotes(goal);
             return (
               <article key={goal.id} className="rounded-[1.5rem] border border-white/80 bg-white/80 p-4 shadow-sm ring-1 ring-white/80">
                 <div className="flex flex-wrap items-start justify-between gap-3">
@@ -188,9 +229,9 @@ export function GoalRoadmapPanel({ goals, tasks, onSaveGoal, onDeleteGoal, onRoa
                 {roadmapState.errorGoalId === goal.id && roadmapState.message ? <p className="mt-3 rounded-2xl bg-rose-50 px-4 py-3 text-sm font-semibold text-rose-600 ring-1 ring-rose-100">{roadmapState.message}</p> : null}
                 {isLoading ? <p className="mt-3 rounded-2xl bg-sky-50 px-4 py-3 text-sm font-semibold text-sky-700 ring-1 ring-sky-100">正在生成路线图建议……</p> : null}
 
-                {!isExpanded && previewItems.length ? (
+                {!isExpanded && roadmapNodes.length ? (
                   <div className="mt-3 flex flex-wrap gap-2">
-                    {previewItems.map((item, index) => <span key={`${item}-${index}`} className="max-w-full truncate rounded-full bg-slate-50 px-3 py-1 text-xs text-slate-500 ring-1 ring-slate-100">{item}</span>)}
+                    {roadmapNodes.slice(0, 2).map((node) => <span key={node.id} className="max-w-full truncate rounded-full bg-slate-50 px-3 py-1 text-xs text-slate-500 ring-1 ring-slate-100">{node.title} · {node.summary}</span>)}
                   </div>
                 ) : null}
 
@@ -199,10 +240,30 @@ export function GoalRoadmapPanel({ goals, tasks, onSaveGoal, onDeleteGoal, onRoa
                     <div className="grid gap-2 md:grid-cols-4">
                       {roadmapFacets.map((facet) => <div key={facet} className="rounded-2xl bg-white/80 px-3 py-2 text-xs font-semibold text-slate-500 ring-1 ring-white/80">{facet}</div>)}
                     </div>
-                    {goal.roadmapSuggestions?.length ? (
-                      <ol className="mt-4 space-y-2 text-sm text-slate-600">
-                        {goal.roadmapSuggestions.map((item, index) => <li key={`${item}-${index}`} className="rounded-2xl bg-white/85 px-4 py-3 leading-6 ring-1 ring-white/80"><span className="mr-2 font-semibold text-slate-400">{index + 1}.</span>{item}</li>)}
-                      </ol>
+                    {roadmapNodes.length ? (
+                      <div className="mt-5">
+                        <ol className="space-y-0">
+                          {roadmapNodes.map((node, index) => {
+                            const isNodeExpanded = expandedNodeIds.includes(node.id);
+                            return <li key={node.id} className="relative pl-7">
+                              {index < roadmapNodes.length - 1 ? <span className="absolute left-[0.55rem] top-5 h-full w-px bg-slate-200" /> : null}
+                              <span className="absolute left-0 top-4 h-[1.15rem] w-[1.15rem] rounded-full border-4 border-white bg-slate-800 shadow-sm" />
+                              <article className="mb-3 rounded-2xl bg-white/85 p-4 ring-1 ring-slate-100">
+                                <div className="flex flex-wrap items-start justify-between gap-3">
+                                  <div className="min-w-0 flex-1">
+                                    <p className="text-xs font-semibold text-slate-400">{node.timeRange}</p>
+                                    <h4 className="mt-1 font-semibold text-slate-900">{node.title}</h4>
+                                    <p className="mt-1 text-sm leading-6 text-slate-500">{node.summary}</p>
+                                  </div>
+                                  <button type="button" onClick={() => toggleNode(node.id)} className="rounded-full bg-slate-50 px-3 py-1.5 text-xs font-semibold text-slate-600 ring-1 ring-slate-100 hover:bg-slate-100">{isNodeExpanded ? '收起' : '展开'}</button>
+                                </div>
+                                {isNodeExpanded ? <div className="mt-3 border-t border-slate-100 pt-3 text-xs leading-6 text-slate-500">{node.details.length ? node.details.map((detail) => <p key={detail}>{detail}</p>) : <p>核心行动：{node.summary}</p>}</div> : null}
+                              </article>
+                            </li>;
+                          })}
+                        </ol>
+                        {roadmapNotes.length ? <div className="mt-3 flex flex-wrap gap-2">{roadmapNotes.map((item, index) => <span key={`${item}-${index}`} className="max-w-full rounded-full bg-slate-50 px-3 py-1.5 text-xs text-slate-500 ring-1 ring-slate-100">{item}</span>)}</div> : null}
+                      </div>
                     ) : <p className="mt-4 rounded-2xl border border-dashed border-slate-200 p-5 text-sm text-slate-400">尚未生成路线图。生成后将保存阶段拆解、风险与周期建议，但不会自动创建任务。</p>}
                   </div>
                 ) : null}

--- a/src/components/LogPage.tsx
+++ b/src/components/LogPage.tsx
@@ -1,9 +1,10 @@
 import { useMemo, useState, type ReactNode } from 'react';
-import type { Achievement, AIArtifact, AIArtifactInput, Goal, PressureBreakdown, PressureHistoryRecord, Task, UserProfile } from '../types/task';
+import type { Achievement, AIArtifact, AIArtifactInput, Goal, PressureBreakdown, PressureHistoryRecord, Task, TaskInput, UserProfile } from '../types/task';
 import { calculateAverageCompletionLeadHours, calculateAverageDailyPressure, calculateAverageImportance, calculateCategoryDistribution, calculateCompletionRate, calculateConsecutiveUsageDays, calculateDailyCompletionHeatmap, calculateDeadlineSurvivalRatio, calculateGoalProgress, calculateLastMinuteCompletionRatio, countAbandonedTasks, countCompletedTasks, countOverdueTasks, getCurrentLifeFocus, getLatestAIInsight } from '../lib/analytics/lifeStats';
 import { analyzeBehavior } from '../lib/behavior/behaviorAnalytics';
 import { calculateBMI, getHealthReadiness } from '../lib/health/healthMetrics';
 import { buildPressureHistogram, calculateContinuousOverloadDays, calculateOverloadFrequency, calculatePressureVolatility, calculateRecoverySpeed, getPressureInsight } from '../lib/pressure/pressureAnalytics';
+import { parseTaskIntakeResponse } from '../services/taskIntakePrompt';
 import { getActivityTypeLabel } from '../utils/taskScoring';
 import { ActivityLog } from './ActivityLog';
 import { AIReviewPanel } from './AIReviewPanel';
@@ -17,7 +18,10 @@ interface DataCenterProps {
   achievements: Achievement[];
   aiArtifacts: AIArtifact[];
   onAIReportGenerated: (artifact: AIArtifactInput) => void;
+  onRecalculatePressureHistory: () => void;
   onDelete: (taskId: string) => void;
+  onEdit: (task: Task) => void;
+  onRestore: (task: Task) => void;
   onReviewNoteChange: (taskId: string, reviewNote: string) => void;
 }
 
@@ -58,8 +62,48 @@ function getPressureMood(pressure: number): string {
   return '平稳：系统暂时有余裕。';
 }
 
+function formatDeadline(deadline?: string): string {
+  if (!deadline) return '未设置';
+  const date = new Date(deadline);
+  if (Number.isNaN(date.getTime())) return '未设置';
+  return new Intl.DateTimeFormat('zh-CN', { dateStyle: 'medium', timeStyle: 'short' }).format(date);
+}
+
+function getTaskIntakeDrafts(artifact: AIArtifact): { drafts?: TaskInput[]; notes?: string; error?: string } {
+  try {
+    const result = parseTaskIntakeResponse(artifact.content);
+    return { drafts: result.tasks, notes: result.notes };
+  } catch {
+    return { error: '草稿解析失败，请重新生成' };
+  }
+}
+
+function getAIArtifactSummary(artifact: AIArtifact): string {
+  if (artifact.kind !== 'task-intake') return `${artifact.content.slice(0, 180)}${artifact.content.length > 180 ? '…' : ''}`;
+  const result = getTaskIntakeDrafts(artifact);
+  if (result.error) return result.error;
+  if (!result.drafts?.length) return result.notes || '没有识别到明确任务。';
+  return `整理出 ${result.drafts.length} 个任务草稿：${result.drafts.slice(0, 3).map((draft) => draft.title).join('、')}${result.drafts.length > 3 ? '…' : ''}`;
+}
+
+function AIArtifactCard({ artifact }: { artifact: AIArtifact }) {
+  const taskIntakeResult = artifact.kind === 'task-intake' ? getTaskIntakeDrafts(artifact) : undefined;
+  return <article className="rounded-3xl bg-white/75 p-4 ring-1 ring-white/80">
+    <div className="flex flex-wrap items-center justify-between gap-2"><h3 className="font-semibold text-slate-950">{artifact.title}</h3><time className="text-xs text-slate-400">{formatTime(artifact.createdAt)}</time></div>
+    {taskIntakeResult ? taskIntakeResult.error ? <p className="mt-3 rounded-2xl bg-rose-50 px-3 py-2 text-sm font-semibold text-rose-600 ring-1 ring-rose-100">{taskIntakeResult.error}</p> : <div className="mt-3 grid gap-3 md:grid-cols-2">
+      {taskIntakeResult.notes ? <p className="text-sm leading-6 text-slate-500 md:col-span-2">{taskIntakeResult.notes}</p> : null}
+      {taskIntakeResult.drafts?.length ? taskIntakeResult.drafts.map((draft, index) => <section key={`${draft.title}-${index}`} className="min-w-0 rounded-2xl bg-slate-50/80 p-3 ring-1 ring-slate-100">
+        <h4 className="font-semibold text-slate-900">{draft.title}</h4>
+        {draft.description ? <p className="mt-2 text-sm leading-6 text-slate-500">{draft.description}</p> : null}
+        <div className="mt-3 flex flex-wrap gap-2 text-xs font-semibold text-slate-500"><span className="rounded-full bg-white px-2.5 py-1 ring-1 ring-slate-100">重要性 {draft.importance}/10</span><span className="rounded-full bg-white px-2.5 py-1 ring-1 ring-slate-100">截止 {formatDeadline(draft.deadline)}</span></div>
+        {draft.decomposition?.length ? <div className="mt-3"><p className="text-xs font-semibold text-slate-500">拆解步骤</p><ul className="mt-1 space-y-1 text-xs leading-5 text-slate-500">{draft.decomposition.slice(0, 5).map((item) => <li key={item}>· {item}</li>)}</ul></div> : null}
+      </section>) : <p className="rounded-2xl border border-dashed border-slate-200 p-4 text-sm text-slate-400 md:col-span-2">没有识别到明确任务。</p>}
+    </div> : <p className="mt-2 whitespace-pre-wrap text-sm leading-6 text-slate-500">{artifact.content.slice(0, 360)}{artifact.content.length > 360 ? '…' : ''}</p>}
+  </article>;
+}
+
 function buildTimelineEvents(tasks: Task[], pressureHistory: PressureHistoryRecord[], achievements: Achievement[], aiArtifacts: AIArtifact[]): TimelineEvent[] {
-  const aiEvents: TimelineEvent[] = aiArtifacts.map((artifact) => ({ id: `ai-${artifact.id}`, timestamp: artifact.createdAt, type: 'ai', title: artifact.title, body: `${artifact.content.slice(0, 180)}${artifact.content.length > 180 ? '…' : ''}`, tone: artifact.kind === 'goal-roadmap' ? 'bg-violet-50 text-violet-700 ring-violet-100' : 'bg-sky-50 text-sky-700 ring-sky-100' }));
+  const aiEvents: TimelineEvent[] = aiArtifacts.map((artifact) => ({ id: `ai-${artifact.id}`, timestamp: artifact.createdAt, type: 'ai', title: artifact.title, body: getAIArtifactSummary(artifact), tone: artifact.kind === 'goal-roadmap' ? 'bg-violet-50 text-violet-700 ring-violet-100' : 'bg-sky-50 text-sky-700 ring-sky-100' }));
   const pressureEvents: TimelineEvent[] = pressureHistory.flatMap((record) => {
     const events: TimelineEvent[] = [];
     if (record.eventType === 'recalibration') events.push({ id: `pressure-recalibration-${record.id}`, timestamp: record.timestamp, type: 'pressure', title: '压力重新校准', body: record.note || `压力映射被重新写入，当前指数 ${record.pressure}。`, tone: 'bg-slate-50 text-slate-700 ring-slate-100' });
@@ -100,7 +144,7 @@ function LifeTimeline({ events }: { events: TimelineEvent[] }) {
   return <SectionShell eyebrow="档案" title="长期人类状态档案"><p className="max-w-2xl text-sm leading-6 text-slate-500">AI 报告、路线图、校准、闭环、逾期、行为信号和压力快照都会留在这里。统计不是数字，是行为镜像。</p>{events.length === 0 ? <div className="mt-5 rounded-3xl border border-dashed border-slate-200 bg-white/65 p-8 text-center text-sm text-slate-400">系统还没有足够的历史。开始记录任务、校准压力或生成 AI 报告后，这里会变成你的生活状态档案。</div> : <ol className="mt-6 space-y-3">{events.map((event) => <li key={event.id} className="grid gap-3 rounded-3xl bg-white/70 p-4 ring-1 ring-white/80 md:grid-cols-[9rem_1fr]"><time className="text-xs font-semibold text-slate-400">{formatTime(event.timestamp)}</time><div><div className="flex flex-wrap items-center gap-2"><span className={`rounded-full px-2.5 py-1 text-[11px] font-semibold ring-1 ${event.tone}`}>{eventTypeLabels[event.type]}</span><h3 className="font-semibold text-slate-950">{event.title}</h3></div><p className="mt-2 whitespace-pre-wrap text-sm leading-6 text-slate-500">{event.body}</p></div></li>)}</ol>}</SectionShell>;
 }
 
-export function LogPage({ tasks, goals, profile, pressure, pressureHistory, achievements, aiArtifacts, onAIReportGenerated, onDelete, onReviewNoteChange }: DataCenterProps) {
+export function LogPage({ tasks, goals, profile, pressure, pressureHistory, achievements, aiArtifacts, onAIReportGenerated, onRecalculatePressureHistory, onDelete, onEdit, onRestore, onReviewNoteChange }: DataCenterProps) {
   const [activeTab, setActiveTab] = useState<DataTab>('overview');
   const behavior = useMemo(() => analyzeBehavior(tasks), [tasks]);
   const timelineEvents = useMemo(() => buildTimelineEvents(tasks, pressureHistory, achievements, aiArtifacts), [achievements, aiArtifacts, pressureHistory, tasks]);
@@ -127,9 +171,9 @@ export function LogPage({ tasks, goals, profile, pressure, pressureHistory, achi
 
     {activeTab === 'overview' ? <section className="space-y-6"><div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4"><StatCard label="已完成" value={completedCount} detail="累计闭环任务。" tone="from-emerald-50 to-white" /><StatCard label="压力" value={pressure.displayPressure} detail={`当前状态：${pressure.label}`} tone="from-rose-50 to-white" /><StatCard label="七日均值" value={avgPressure} detail="近 7 天平均压力。" tone="from-sky-50 to-white" /><StatCard label="连续记录" value={`${usageStreak} 天`} detail="连续使用 VD 的天数。" tone="from-violet-50 to-white" /></div><SectionShell eyebrow="行为状态" title="当前行为状态"><div className="grid gap-4 lg:grid-cols-[1.1fr_0.9fr]"><div className="rounded-3xl bg-slate-50/80 p-5 ring-1 ring-white/80"><p className="text-2xl font-semibold text-slate-950">{behavior.currentState}</p><p className="mt-3 text-sm leading-6 text-slate-500">{getLatestAIInsight(aiArtifacts)}</p></div><div className="grid gap-3 sm:grid-cols-2"><StatCard label="生活重心" value={getCurrentLifeFocus(tasks)} detail="当前生活重心。" /><StatCard label="目标进度" value={`${goalProgress}%`} detail="长期目标关联任务推进度。" /></div></div></SectionShell><LifeTimeline events={timelineEvents.slice(0, 12)} /></section> : null}
 
-    {activeTab === 'tasks' ? <section className="space-y-6"><div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4"><StatCard label="已完成" value={completedCount} detail="总完成任务。" /><StatCard label="已逾期" value={overdueCount} detail="当前逾期任务。" tone="from-amber-50 to-white" /><StatCard label="已放弃" value={abandonedCount} detail="主动放弃或中止。" /><StatCard label="完成率" value={`${calculateCompletionRate(tasks)}%`} detail="已解决事项中的完成率。" /></div><SectionShell eyebrow="执行模式" title="行为执行模式"><div className="grid gap-4 lg:grid-cols-2"><div className="space-y-3 rounded-3xl bg-white/70 p-5 ring-1 ring-white/80"><p>平均在截止前 <b>{calculateAverageCompletionLeadHours(tasks)}</b> 小时完成任务。</p><p><b>{calculateLastMinuteCompletionRatio(tasks)}%</b> 的任务在最后一小时内完成。</p><p>截止存活率：<b>{calculateDeadlineSurvivalRatio(tasks)}%</b></p><p>平均重要性：<b>{calculateAverageImportance(tasks)}</b>/10</p></div><div className="grid gap-3 sm:grid-cols-2"><StatCard label="拖延倾向" value={behavior.procrastinationTendency} detail="基于逾期与最后一小时完成比例。" /><StatCard label="执行稳定性" value={behavior.executionConsistency} detail="基于完成率与任务状态。" /><StatCard label="截止依赖" value={behavior.urgencyDependence} detail="是否依赖截止时间启动。" /><StatCard label="爆发推进" value={behavior.burstProductivityTendency} detail="是否呈现短周期集中完成。" /></div></div><div className="mt-5"><Heatmap values={heatmap} /></div></SectionShell><ActivityLog tasks={tasks} limit={Infinity} title="任务归档 / 事件流" onDelete={onDelete} onReviewNoteChange={onReviewNoteChange} /></section> : null}
+    {activeTab === 'tasks' ? <section className="space-y-6"><div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4"><StatCard label="已完成" value={completedCount} detail="总完成任务。" /><StatCard label="已逾期" value={overdueCount} detail="当前逾期任务。" tone="from-amber-50 to-white" /><StatCard label="已放弃" value={abandonedCount} detail="主动放弃或中止。" /><StatCard label="完成率" value={`${calculateCompletionRate(tasks)}%`} detail="已解决事项中的完成率。" /></div><SectionShell eyebrow="执行模式" title="行为执行模式"><div className="grid gap-4 lg:grid-cols-2"><div className="space-y-3 rounded-3xl bg-white/70 p-5 ring-1 ring-white/80"><p>平均在截止前 <b>{calculateAverageCompletionLeadHours(tasks)}</b> 小时完成任务。</p><p><b>{calculateLastMinuteCompletionRatio(tasks)}%</b> 的任务在最后一小时内完成。</p><p>截止存活率：<b>{calculateDeadlineSurvivalRatio(tasks)}%</b></p><p>平均重要性：<b>{calculateAverageImportance(tasks)}</b>/10</p></div><div className="grid gap-3 sm:grid-cols-2"><StatCard label="拖延倾向" value={behavior.procrastinationTendency} detail="基于逾期与最后一小时完成比例。" /><StatCard label="执行稳定性" value={behavior.executionConsistency} detail="基于完成率与任务状态。" /><StatCard label="截止依赖" value={behavior.urgencyDependence} detail="是否依赖截止时间启动。" /><StatCard label="爆发推进" value={behavior.burstProductivityTendency} detail="是否呈现短周期集中完成。" /></div></div><div className="mt-5"><Heatmap values={heatmap} /></div></SectionShell><ActivityLog tasks={tasks} limit={Infinity} title="任务归档 / 事件流" onDelete={onDelete} onEdit={onEdit} onRestore={onRestore} onReviewNoteChange={onReviewNoteChange} /></section> : null}
 
-    {activeTab === 'pressure' ? <section className="space-y-6"><div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4"><StatCard label="实时压力" value={pressure.displayPressure} detail={pressure.recommendation} tone="from-rose-50 to-white" /><StatCard label="波动性" value={calculatePressureVolatility(pressureHistory)} detail="压力标准差估计。" /><StatCard label="高压占比" value={`${calculateOverloadFrequency(pressureHistory)}%`} detail="高压/过载记录占比。" /><StatCard label="连续高压" value={`${calculateContinuousOverloadDays(pressureHistory)} 天`} detail="连续过载天数。" /></div><SectionShell eyebrow="压力核心" title="压力监控系统"><div className="grid gap-5 lg:grid-cols-[1.2fr_0.8fr]"><TinyBars values={pressureHistory.slice(-24).map((record) => record.pressure)} /><div className="rounded-3xl bg-slate-50/80 p-5 ring-1 ring-white/80"><p className="font-semibold text-slate-950">{getPressureInsight(pressureHistory)}</p><p className="mt-3 text-sm text-slate-500">恢复速度：{calculateRecoverySpeed(pressureHistory)}</p><p className="mt-2 text-sm text-slate-500">分布：[0-30, 31-60, 61-80, 81-100, 100+] = {histogram.join(' / ')}</p></div></div></SectionShell><LifeTimeline events={timelineEvents.filter((event) => event.type === 'pressure' || event.type === 'emotion').slice(0, 20)} /></section> : null}
+    {activeTab === 'pressure' ? <section className="space-y-6"><div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4"><StatCard label="实时压力" value={pressure.displayPressure} detail={pressure.recommendation} tone="from-rose-50 to-white" /><StatCard label="波动性" value={calculatePressureVolatility(pressureHistory)} detail="压力标准差估计。" /><StatCard label="高压占比" value={`${calculateOverloadFrequency(pressureHistory)}%`} detail="高压/过载记录占比。" /><StatCard label="连续高压" value={`${calculateContinuousOverloadDays(pressureHistory)} 天`} detail="连续过载天数。" /></div><SectionShell eyebrow="压力核心" title="压力监控系统"><div className="mb-4 flex flex-wrap items-center justify-between gap-3 rounded-2xl bg-white/70 p-3 ring-1 ring-white/80"><p className="text-sm leading-6 text-slate-500">仅清理可识别的任务推导点；手动记录和无来源老数据会保留。</p><button type="button" onClick={onRecalculatePressureHistory} className="rounded-full bg-slate-950 px-4 py-2 text-xs font-semibold text-white hover:bg-slate-800">重算压力曲线 / 清理异常点</button></div><div className="grid gap-5 lg:grid-cols-[1.2fr_0.8fr]"><TinyBars values={pressureHistory.slice(-24).map((record) => record.pressure)} /><div className="rounded-3xl bg-slate-50/80 p-5 ring-1 ring-white/80"><p className="font-semibold text-slate-950">{getPressureInsight(pressureHistory)}</p><p className="mt-3 text-sm text-slate-500">恢复速度：{calculateRecoverySpeed(pressureHistory)}</p><p className="mt-2 text-sm text-slate-500">分布：[0-30, 31-60, 61-80, 81-100, 100+] = {histogram.join(' / ')}</p></div></div></SectionShell><LifeTimeline events={timelineEvents.filter((event) => event.type === 'pressure' || event.type === 'emotion').slice(0, 20)} /></section> : null}
 
     {activeTab === 'life' ? <section className="space-y-6"><SectionShell eyebrow="人生结构" title="人生结构分布"><div className="grid gap-4 lg:grid-cols-[0.8fr_1.2fr]"><div className="space-y-3">{categoryDistribution.map((item) => <div key={item.category} className="rounded-2xl bg-white/75 p-3 ring-1 ring-white/80"><div className="flex justify-between text-sm font-semibold text-slate-600"><span>{getActivityTypeLabel(item.category)}</span><span>{item.ratio}%</span></div><div className="mt-2 h-2 rounded-full bg-slate-100"><div className="h-full rounded-full bg-slate-800" style={{ width: `${item.ratio}%` }} /></div></div>)}</div><div className="rounded-3xl bg-slate-50/80 p-5 ring-1 ring-white/80"><p className="text-xl font-semibold text-slate-950">当前人生重心：{getCurrentLifeFocus(tasks)}</p><p className="mt-3 text-sm leading-6 text-slate-500">娱乐比例、自我维护比例、社交活动趋势与长期目标推进会在这里持续沉淀。VD 会观察偏移、忽视、过度聚焦和结构失衡。</p><p className="mt-4 text-sm font-semibold text-slate-700">长期目标进度：{goalProgress}%</p></div></div></SectionShell></section> : null}
 
@@ -137,6 +181,6 @@ export function LogPage({ tasks, goals, profile, pressure, pressureHistory, achi
 
     {activeTab === 'trends' ? <section className="space-y-6"><SectionShell eyebrow="长期视角" title="长期趋势系统"><div className="grid gap-5 lg:grid-cols-[1.2fr_0.8fr]"><TinyBars values={pressureHistory.slice(-36).map((record) => record.pressure)} /><div className="space-y-3"><StatCard label="本月高压天数" value={calculateContinuousOverloadDays(pressureHistory)} detail="当前连续样本，未来扩展为月度统计。" /><StatCard label="执行演化" value={behavior.executionConsistency} detail="过去行为形成的稳定性判断。" /></div></div><p className="mt-5 text-sm leading-7 text-slate-500">这里将扩展为月度演化、季节性变化、年度回顾、习惯一致性、压力演化、执行演化与健康演化。</p></SectionShell></section> : null}
 
-    {activeTab === 'ai' ? <section className="space-y-6"><SectionShell eyebrow="AI 洞察" title="第三人称行为观察"><p className="text-sm leading-7 text-slate-500">AI 不负责鼓励你。它负责观察：压力模式、行为倾向、恢复速度、长期任务稳定性、风险和节奏建议。</p><div className="mt-5 grid gap-3">{aiArtifacts.slice(0, 8).map((artifact) => <article key={artifact.id} className="rounded-3xl bg-white/75 p-4 ring-1 ring-white/80"><div className="flex flex-wrap items-center justify-between gap-2"><h3 className="font-semibold text-slate-950">{artifact.title}</h3><time className="text-xs text-slate-400">{formatTime(artifact.createdAt)}</time></div><p className="mt-2 whitespace-pre-wrap text-sm leading-6 text-slate-500">{artifact.content.slice(0, 360)}{artifact.content.length > 360 ? '…' : ''}</p></article>)}</div></SectionShell><AIReviewPanel tasks={tasks} pressureHistory={pressureHistory} onAIReportGenerated={onAIReportGenerated} /></section> : null}
+    {activeTab === 'ai' ? <section className="space-y-6"><SectionShell eyebrow="AI 洞察" title="第三人称行为观察"><p className="text-sm leading-7 text-slate-500">AI 不负责鼓励你。它负责观察：压力模式、行为倾向、恢复速度、长期任务稳定性、风险和节奏建议。</p><div className="mt-5 grid gap-3">{aiArtifacts.length ? aiArtifacts.slice(0, 8).map((artifact) => <AIArtifactCard key={artifact.id} artifact={artifact} />) : <div className="rounded-3xl border border-dashed border-slate-200 bg-white/65 p-8 text-center text-sm text-slate-400">尚未生成 AI 洞察。完成一次任务整理或行为分析后，这里会展示可读摘要。</div>}</div></SectionShell><AIReviewPanel tasks={tasks} pressureHistory={pressureHistory} onAIReportGenerated={onAIReportGenerated} /></section> : null}
   </section>;
 }

--- a/src/components/PriorityMap.tsx
+++ b/src/components/PriorityMap.tsx
@@ -6,10 +6,20 @@ import { ProgressBar } from './ProgressBar';
 
 interface PriorityMapProps {
   tasks: Task[];
+  onEditTask?: (task: Task) => void;
+  onCompleteTask?: (task: Task) => void;
+  onDeleteTask?: (taskId: string) => void;
 }
 
 interface PositionedTask {
   task: Task;
+  left: number;
+  bottom: number;
+}
+
+interface TaskCluster {
+  id: string;
+  tasks: PositionedTask[];
   left: number;
   bottom: number;
 }
@@ -54,6 +64,20 @@ function getPositionedTask(task: Task): PositionedTask {
   };
 }
 
+function clusterPositionedTasks(tasks: PositionedTask[]): TaskCluster[] {
+  const clusters = new Map<string, PositionedTask[]>();
+  tasks.forEach((task) => {
+    const id = `${Math.round(task.left / 14)}-${Math.round(task.bottom / 14)}`;
+    clusters.set(id, [...(clusters.get(id) ?? []), task]);
+  });
+  return Array.from(clusters, ([id, clusterTasks]) => ({
+    id,
+    tasks: clusterTasks,
+    left: clusterTasks.reduce((sum, item) => sum + item.left, 0) / clusterTasks.length,
+    bottom: clusterTasks.reduce((sum, item) => sum + item.bottom, 0) / clusterTasks.length,
+  }));
+}
+
 function getHoverCardStyle(positionedTask: PositionedTask): CSSProperties {
   const top = Math.min(78, Math.max(22, 100 - positionedTask.bottom));
   const shouldPlaceLeft = positionedTask.left > 50;
@@ -96,6 +120,7 @@ function TaskDetailContent({ task }: { task: Task }) {
       {task.description ? <p className="mt-3 text-sm text-slate-600">{task.description}</p> : null}
       <div className="mt-4 space-y-2 text-sm text-slate-600">
         <p>重要性 {task.importance}/10</p>
+        <p>紧急程度 {getUrgencyScore(task.deadline)}</p>
         <p>{formatCountdown(task.deadline)}</p>
         <p className="text-xs text-slate-400">截止 {formatDeadline(task.deadline)}</p>
         <p className="rounded-2xl bg-sky-50 px-3 py-2 text-sky-700">{getRecommendationReason(task)}</p>
@@ -108,13 +133,22 @@ function TaskDetailContent({ task }: { task: Task }) {
   );
 }
 
-export function PriorityMap({ tasks }: PriorityMapProps) {
+export function PriorityMap({ tasks, onEditTask, onCompleteTask, onDeleteTask }: PriorityMapProps) {
   const [now, setNow] = useState(() => new Date());
   const positionedTasks = useMemo(() => tasks.map(getPositionedTask), [tasks]);
+  const mobileClusters = useMemo(() => clusterPositionedTasks(positionedTasks), [positionedTasks]);
+  const topTasks = useMemo(() => [...tasks].sort((left, right) => getUrgencyScore(right.deadline) + right.importance * 10 - getUrgencyScore(left.deadline) - left.importance * 10).slice(0, 5), [tasks]);
   const [hoverTaskId, setHoverTaskId] = useState<string | undefined>(undefined);
   const [selectedTaskId, setSelectedTaskId] = useState<string | undefined>(undefined);
+  const [selectedClusterId, setSelectedClusterId] = useState<string | undefined>(undefined);
   const hoverPositionedTask = positionedTasks.find(({ task }) => task.id === hoverTaskId);
   const selectedTask = positionedTasks.find(({ task }) => task.id === selectedTaskId)?.task;
+  const selectedCluster = mobileClusters.find((cluster) => cluster.id === selectedClusterId);
+
+  function closeTaskDetail() {
+    setSelectedTaskId(undefined);
+    setSelectedClusterId(undefined);
+  }
 
   useEffect(() => {
     const intervalId = window.setInterval(() => setNow(new Date()), 1_000);
@@ -176,7 +210,7 @@ export function PriorityMap({ tasks }: PriorityMapProps) {
                 onMouseLeave={() => setHoverTaskId(undefined)}
                 onFocus={() => setHoverTaskId(task.id)}
                 onBlur={() => setHoverTaskId(undefined)}
-                className="group absolute z-10 -translate-x-1/2 translate-y-1/2 text-left outline-none"
+                className="group absolute z-10 hidden -translate-x-1/2 translate-y-1/2 text-left outline-none md:block"
                 style={{ left: `${left}%`, bottom: `${bottom}%` }}
                 aria-label={`查看任务 ${task.title}`}
               >
@@ -191,8 +225,15 @@ export function PriorityMap({ tasks }: PriorityMapProps) {
             );
           })}
 
+          <div className="md:hidden">
+            {mobileClusters.map((cluster) => {
+              const firstTask = cluster.tasks[0].task;
+              return <button key={cluster.id} type="button" onClick={() => { setSelectedTaskId(firstTask.id); setSelectedClusterId(cluster.id); }} className="absolute z-10 -translate-x-1/2 translate-y-1/2 rounded-full border-4 border-white bg-slate-800 text-xs font-bold text-white shadow-md" style={{ left: `${cluster.left}%`, bottom: `${cluster.bottom}%`, width: cluster.tasks.length > 1 ? '2rem' : '1.25rem', height: cluster.tasks.length > 1 ? '2rem' : '1.25rem' }} aria-label={cluster.tasks.length > 1 ? `查看附近 ${cluster.tasks.length} 个任务` : `查看任务 ${firstTask.title}`}>{cluster.tasks.length > 1 ? cluster.tasks.length : ''}</button>;
+            })}
+          </div>
+
           {hoverPositionedTask && !selectedTask ? (
-            <div className="pointer-events-none absolute z-20 w-64 rounded-2xl bg-white/90 p-3 shadow-xl shadow-slate-200/60 ring-1 ring-white/80 backdrop-blur" style={getHoverCardStyle(hoverPositionedTask)}>
+            <div className="pointer-events-none absolute z-20 hidden w-64 md:block rounded-2xl bg-white/90 p-3 shadow-xl shadow-slate-200/60 ring-1 ring-white/80 backdrop-blur" style={getHoverCardStyle(hoverPositionedTask)}>
               <p className="truncate text-sm font-bold text-slate-950">{hoverPositionedTask.task.title}</p>
               <p className="mt-2 text-xs text-slate-600">{formatCountdown(hoverPositionedTask.task.deadline)}</p>
               <p className="mt-2 rounded-xl bg-sky-50 px-2.5 py-1.5 text-xs text-sky-700">{getRecommendationReason(hoverPositionedTask.task)}</p>
@@ -204,24 +245,31 @@ export function PriorityMap({ tasks }: PriorityMapProps) {
           ) : null}
 
           {selectedTask ? (
-            <div className="absolute inset-0 z-30 flex items-center justify-center bg-slate-900/15 p-6 backdrop-blur-sm">
-              <div className="w-full max-w-xl rounded-[2rem] bg-white/95 p-6 shadow-2xl shadow-slate-300/40 ring-1 ring-white/80 backdrop-blur">
+            <div className="absolute inset-0 z-30 flex items-end justify-center bg-slate-900/15 p-3 backdrop-blur-sm md:items-center md:p-6">
+              <div className="max-h-[92%] w-full max-w-xl overflow-y-auto rounded-[2rem] bg-white/95 p-5 md:p-6 shadow-2xl shadow-slate-300/40 ring-1 ring-white/80 backdrop-blur">
                 <div className="mb-4 flex justify-end">
                   <button
                     type="button"
-                    onClick={() => setSelectedTaskId(undefined)}
+                    onClick={closeTaskDetail}
                     className="rounded-full bg-slate-100 px-3 py-1.5 text-xs font-semibold text-slate-600 hover:bg-slate-200"
                     aria-label="关闭任务详情"
                   >
                     关闭
                   </button>
                 </div>
+                {selectedCluster && selectedCluster.tasks.length > 1 ? <div className="mb-4 rounded-2xl bg-slate-50 p-3 ring-1 ring-slate-100 md:hidden"><p className="text-xs font-semibold text-slate-500">附近 {selectedCluster.tasks.length} 个任务</p><div className="mt-2 flex flex-wrap gap-2">{selectedCluster.tasks.map(({ task }) => <button key={task.id} type="button" onClick={() => setSelectedTaskId(task.id)} className={`rounded-full px-3 py-1.5 text-xs font-semibold ${selectedTask.id === task.id ? 'bg-slate-950 text-white' : 'bg-white text-slate-600 ring-1 ring-slate-100'}`}>{task.title}</button>)}</div></div> : null}
                 <TaskDetailContent task={selectedTask} />
+                <div className="mt-5 flex flex-wrap justify-end gap-2">
+                  {onEditTask ? <button type="button" onClick={() => { closeTaskDetail(); onEditTask(selectedTask); }} className="rounded-full bg-slate-100 px-4 py-2 text-xs font-semibold text-slate-700 hover:bg-slate-200">编辑</button> : null}
+                  {onCompleteTask ? <button type="button" onClick={() => { closeTaskDetail(); onCompleteTask(selectedTask); }} className="rounded-full bg-emerald-50 px-4 py-2 text-xs font-semibold text-emerald-700 hover:bg-emerald-100">完成</button> : null}
+                  {onDeleteTask ? <button type="button" onClick={() => { closeTaskDetail(); onDeleteTask(selectedTask.id); }} className="rounded-full bg-rose-50 px-4 py-2 text-xs font-semibold text-rose-600 hover:bg-rose-100">删除</button> : null}
+                </div>
               </div>
             </div>
           ) : null}
         </div>
       </div>
+      <div className="mt-5 md:hidden"><h3 className="text-sm font-semibold text-slate-700">当前最值得关注的任务 Top 5</h3>{topTasks.length ? <ol className="mt-3 space-y-2">{topTasks.map((task, index) => <li key={task.id}><button type="button" onClick={() => setSelectedTaskId(task.id)} className="flex w-full items-center justify-between gap-3 rounded-2xl bg-slate-50 px-3 py-2 text-left ring-1 ring-slate-100"><span className="min-w-0 truncate text-sm font-medium text-slate-700">{index + 1}. {task.title}</span><span className="shrink-0 text-xs text-slate-400">重要性 {task.importance} · 紧急 {getUrgencyScore(task.deadline)}</span></button></li>)}</ol> : <p className="mt-3 rounded-2xl border border-dashed border-slate-200 p-4 text-center text-sm text-slate-400">暂无进行中的任务。</p>}</div>
     </section>
   );
 }

--- a/src/components/SocialPage.tsx
+++ b/src/components/SocialPage.tsx
@@ -1,7 +1,5 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState, type Dispatch, type SetStateAction } from 'react';
 import { applyNodeChanges, Background, Controls, ReactFlow, type Edge, type Node, type NodeChange } from '@xyflow/react';
-import { useLocalStorage } from '../hooks/useLocalStorage';
-import { storageKeys } from '../storage';
 import type { SocialPersonData } from '../types/task';
 
 const CURRENT_SOCIAL_LAYOUT_VERSION = 10;
@@ -235,9 +233,14 @@ function formatLastInteraction(value?: string): string {
   return new Intl.DateTimeFormat('zh-CN', { month: 'short', day: 'numeric' }).format(new Date(timestamp));
 }
 
-export function SocialPage() {
-  const [storedNodes, setStoredNodes] = useLocalStorage<SocialNode[]>(storageKeys.socialNodes, seedNodes());
-  const [layoutVersion, setLayoutVersion] = useLocalStorage<number>(storageKeys.socialLayoutVersion, 0);
+interface SocialPageProps {
+  storedNodes: unknown[];
+  setStoredNodes: Dispatch<SetStateAction<unknown[]>>;
+  layoutVersion: number;
+  setLayoutVersion: Dispatch<SetStateAction<number>>;
+}
+
+export function SocialPage({ storedNodes, setStoredNodes, layoutVersion, setLayoutVersion }: SocialPageProps) {
   const normalizedNodes = useMemo(() => normalizeNodes(storedNodes), [storedNodes]);
   const relationshipEdges = useMemo(() => buildRelationshipEdges(normalizedNodes), [normalizedNodes]);
   const [editingNode, setEditingNode] = useState<SocialNode | undefined>();

--- a/src/components/TaskForm.tsx
+++ b/src/components/TaskForm.tsx
@@ -9,6 +9,12 @@ interface TaskFormProps {
   onSubmit: (task: TaskInput) => void;
 }
 
+function toOptionalDatetimeLocalValue(value?: string): string | undefined {
+  if (!value) return undefined;
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? undefined : toDatetimeLocalValue(date);
+}
+
 const activityTypes: ActivityType[] = ['task', 'schedule', 'study', 'research', 'fitness', 'exercise', 'work', 'life', 'social', 'recovery', 'entertainment', 'other'];
 
 const defaultValues: TaskInput = {
@@ -23,10 +29,10 @@ const defaultValues: TaskInput = {
 };
 
 export function TaskForm({ task, onCancel, onSubmit }: TaskFormProps) {
-  const [values, setValues] = useState<TaskInput>(task ?? defaultValues);
+  const [values, setValues] = useState<TaskInput>(task ? { ...task, deadline: toOptionalDatetimeLocalValue(task.deadline), completedAt: toOptionalDatetimeLocalValue(task.completedAt) } : defaultValues);
 
   useEffect(() => {
-    setValues(task ?? defaultValues);
+    setValues(task ? { ...task, deadline: toOptionalDatetimeLocalValue(task.deadline), completedAt: toOptionalDatetimeLocalValue(task.completedAt) } : defaultValues);
   }, [task]);
 
   function handleSubmit(event: FormEvent<HTMLFormElement>) {
@@ -39,6 +45,7 @@ export function TaskForm({ task, onCancel, onSubmit }: TaskFormProps) {
       title: values.title.trim(),
       description: values.description?.trim() || undefined,
       deadline: values.deadline || undefined,
+      completedAt: values.lifecycleStatus === 'completed' ? values.completedAt || new Date().toISOString() : undefined,
       importance: clampImportance(values.importance),
       progress: clampProgress(values.progress),
       progressMode: values.progressMode,
@@ -86,11 +93,13 @@ export function TaskForm({ task, onCancel, onSubmit }: TaskFormProps) {
       {task ? (
         <div>
           <label className="text-sm font-medium text-slate-600" htmlFor="lifecycleStatus">状态</label>
-          <select id="lifecycleStatus" value={values.lifecycleStatus} onChange={(event) => setValues({ ...values, lifecycleStatus: event.target.value as LifecycleStatus })} className="mt-2 w-full rounded-2xl border border-slate-200/80 bg-white/80 px-4 py-3 outline-none transition focus:border-sky-200 focus:ring-4 focus:ring-sky-100/70">
+          <select id="lifecycleStatus" value={values.lifecycleStatus} onChange={(event) => { const lifecycleStatus = event.target.value as LifecycleStatus; setValues({ ...values, lifecycleStatus, progress: lifecycleStatus === 'active' && values.progress >= 100 ? 0 : values.progress, taskProgress: lifecycleStatus === 'active' && (values.taskProgress ?? values.progress) >= 100 ? 0 : values.taskProgress }); }} className="mt-2 w-full rounded-2xl border border-slate-200/80 bg-white/80 px-4 py-3 outline-none transition focus:border-sky-200 focus:ring-4 focus:ring-sky-100/70">
             <option value="active">进行中</option><option value="completed">已完成</option><option value="abandoned">已放弃</option>
           </select>
         </div>
       ) : null}
+
+      {task && values.lifecycleStatus === 'completed' ? <div><label className="text-sm font-medium text-slate-600" htmlFor="completedAt">完成时间</label><input id="completedAt" type="datetime-local" value={values.completedAt ?? ''} onChange={(event) => setValues({ ...values, completedAt: event.target.value })} className="mt-2 w-full rounded-2xl border border-slate-200/80 bg-white/80 px-4 py-3 outline-none transition focus:border-sky-200 focus:ring-4 focus:ring-sky-100/70" /></div> : null}
 
       <div className="flex flex-wrap justify-end gap-3 pt-1">
         <button type="button" onClick={onCancel} className="rounded-full px-5 py-2.5 text-sm font-medium text-slate-500 hover:bg-slate-100">取消</button>

--- a/src/components/TaskPage.tsx
+++ b/src/components/TaskPage.tsx
@@ -53,7 +53,7 @@ export function TaskPage({ tasks, activeTasks, achievements, pressure, onAddTask
         </div>
         <p className="mt-3 rounded-2xl bg-slate-50 px-3 py-2 text-sm text-slate-600">{weeklyReport.summary}</p>
       </section>
-      <PriorityMap tasks={activeTasks} />
+      <PriorityMap tasks={activeTasks} onEditTask={onEditTask} onCompleteTask={(task) => onArchiveTask(task, 'completed')} onDeleteTask={onDeleteTask} />
       <AITaskAnalysisPanel tasks={tasks} pressure={pressure} onAIConnected={onAIConnected} onAIReportGenerated={onAIReportGenerated} />
       <TaskList tasks={activeTasks} onArchive={onArchiveTask} onDelete={onDeleteTask} onEdit={onEditTask} />
       <AchievementsPanel achievements={achievements} />

--- a/src/lib/cloudSync.ts
+++ b/src/lib/cloudSync.ts
@@ -12,6 +12,8 @@ interface ProfileData {
   profile: UserProfile | null;
   pressureCalibration: PressureCalibrationSnapshot | null;
   onboardingComplete: boolean | null;
+  socialNodes?: unknown[];
+  socialLayoutVersion?: number;
 }
 
 interface ProfileRow {
@@ -30,6 +32,8 @@ export interface CloudData {
   profile: UserProfile | null;
   pressureCalibration: PressureCalibrationSnapshot | null;
   onboardingComplete: boolean | null;
+  socialNodes: unknown[] | null;
+  socialLayoutVersion: number | null;
 }
 
 const encode = (value: string) => encodeURIComponent(value).replace(/'/g, '%27');
@@ -112,6 +116,8 @@ export async function loadCloudData(session: SupabaseSession): Promise<CloudData
       profile: profileData?.profile ?? null,
       pressureCalibration: profileData?.pressureCalibration ?? null,
       onboardingComplete: typeof profileData?.onboardingComplete === 'boolean' ? profileData.onboardingComplete : null,
+      socialNodes: Array.isArray(profileData?.socialNodes) ? profileData.socialNodes : null,
+      socialLayoutVersion: typeof profileData?.socialLayoutVersion === 'number' ? profileData.socialLayoutVersion : null,
     };
   })());
 }
@@ -128,7 +134,7 @@ export async function saveCloudPressureHistory(records: PressureHistoryRecord[],
   await withCloudSyncErrors(replaceJsonRows('pressure_logs', records, session));
 }
 
-export async function saveCloudProfile(input: { profile: UserProfile; pressureCalibration: PressureCalibrationSnapshot; onboardingComplete: boolean }, session: SupabaseSession): Promise<void> {
+export async function saveCloudProfile(input: { profile: UserProfile; pressureCalibration: PressureCalibrationSnapshot; onboardingComplete: boolean; socialNodes: unknown[]; socialLayoutVersion: number }, session: SupabaseSession): Promise<void> {
   await withCloudSyncErrors(supabase.rest('profiles', {
     method: 'POST',
     headers: { Prefer: 'resolution=merge-duplicates,return=minimal' },
@@ -141,6 +147,8 @@ export async function saveCloudProfile(input: { profile: UserProfile; pressureCa
         profile: input.profile,
         pressureCalibration: input.pressureCalibration,
         onboardingComplete: input.onboardingComplete,
+        socialNodes: input.socialNodes,
+        socialLayoutVersion: input.socialLayoutVersion,
       },
       updated_at: new Date().toISOString(),
     }),

--- a/src/services/goals/roadmapPrompt.ts
+++ b/src/services/goals/roadmapPrompt.ts
@@ -14,7 +14,7 @@ Rules:
 
 Return JSON shape:
 {
-  "stages": ["阶段建议，含阶段目标与顺序"],
+  "stages": [{ "title": "阶段名", "timeRange": "时间范围", "coreAction": "一句话核心行动" }],
   "milestones": ["关键里程碑，含可验证结果"],
   "weeklyMonthlyDirection": ["每周或每月推进方向"],
   "risks": ["风险与规避建议"],
@@ -59,6 +59,19 @@ function toStringList(value: unknown): string[] {
   return value.filter((item): item is string => typeof item === 'string' && Boolean(item.trim())).map((item) => item.trim());
 }
 
+function toStageList(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((item) => {
+    if (typeof item === 'string' && item.trim()) return [item.trim()];
+    if (!item || typeof item !== 'object') return [];
+    const stage = item as Record<string, unknown>;
+    const title = typeof stage.title === 'string' ? stage.title.trim() : '';
+    const timeRange = typeof stage.timeRange === 'string' ? stage.timeRange.trim() : '';
+    const coreAction = typeof stage.coreAction === 'string' ? stage.coreAction.trim() : '';
+    return title || coreAction ? [`${title || '未命名阶段'}｜${timeRange || '时间范围待确认'}｜${coreAction || title}`] : [];
+  });
+}
+
 function addSection(items: string[], title: string, values: string[]): void {
   values.slice(0, 6).forEach((value) => items.push(`${title}：${value}`));
 }
@@ -74,7 +87,7 @@ export function parseGoalRoadmapResponse(content: string): { roadmapSuggestions:
   if (!parsed || typeof parsed !== 'object') throw new Error('AI 返回 JSON 结构无效。');
   const payload = parsed as { stages?: unknown; milestones?: unknown; weeklyMonthlyDirection?: unknown; risks?: unknown; firstActions?: unknown; roadmapSuggestions?: unknown; notes?: unknown };
   const roadmapSuggestions: string[] = [];
-  addSection(roadmapSuggestions, '阶段', toStringList(payload.stages));
+  addSection(roadmapSuggestions, '阶段', toStageList(payload.stages));
   addSection(roadmapSuggestions, '里程碑', toStringList(payload.milestones));
   addSection(roadmapSuggestions, '周/月方向', toStringList(payload.weeklyMonthlyDirection));
   addSection(roadmapSuggestions, '风险', toStringList(payload.risks));

--- a/src/types/task.ts
+++ b/src/types/task.ts
@@ -31,7 +31,7 @@ export interface Task {
   updatedAt: string;
 }
 
-export type TaskInput = Omit<Task, 'id' | 'schemaVersion' | 'createdAt' | 'updatedAt' | 'completedAt' | 'abandonedAt'>;
+export type TaskInput = Omit<Task, 'id' | 'schemaVersion' | 'createdAt' | 'updatedAt' | 'completedAt' | 'abandonedAt'> & { completedAt?: string };
 
 export type PressureState = 'steady' | 'manageable' | 'high' | 'overload' | 'burnout';
 
@@ -70,6 +70,7 @@ export interface PressureCalibrationSnapshot {
 
 
 export type PressureHistoryEventType = 'auto' | 'task_created' | 'task_completed' | 'task_abandoned' | 'recalibration' | 'manual';
+export type PressureHistorySource = 'manual' | 'task_derived';
 
 export interface PressureHistoryRecord {
   id: string;
@@ -82,6 +83,7 @@ export interface PressureHistoryRecord {
   recoveryRelief: number;
   note?: string;
   eventType?: PressureHistoryEventType;
+  source?: PressureHistorySource;
 }
 
 export interface PressureBreakdown {

--- a/src/utils/pressureHistory.ts
+++ b/src/utils/pressureHistory.ts
@@ -1,4 +1,4 @@
-import type { PressureBreakdown, PressureHistoryEventType, PressureHistoryRecord, Task } from '../types/task';
+import type { PressureBreakdown, PressureHistoryEventType, PressureHistoryRecord, PressureHistorySource, Task } from '../types/task';
 
 const AUTO_RECORD_WINDOW_MS = 30 * 60 * 1000;
 const EVENT_SETTLE_WINDOW_MS = 2 * 60 * 1000;
@@ -36,6 +36,7 @@ export function normalizePressureHistory(records: unknown): PressureHistoryRecor
       recoveryRelief: typeof record.recoveryRelief === 'number' && Number.isFinite(record.recoveryRelief) ? Math.max(0, record.recoveryRelief) : 0,
       note: record.note || undefined,
       eventType: record.eventType || 'auto',
+      source: record.source === 'manual' || record.source === 'task_derived' ? record.source : undefined,
     }))
     .sort((a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime())
     .slice(-MAX_HISTORY_RECORDS);
@@ -47,6 +48,7 @@ export function createPressureHistoryRecord(
   eventType: PressureHistoryEventType = 'auto',
   note?: string,
   timestamp = new Date(),
+  source: PressureHistorySource = eventType === 'manual' || eventType === 'recalibration' ? 'manual' : 'task_derived',
 ): PressureHistoryRecord {
   const todayCounts = countTasksForToday(tasks, timestamp);
 
@@ -61,6 +63,7 @@ export function createPressureHistoryRecord(
     recoveryRelief: pressure.recoveryRelief,
     note,
     eventType,
+    source,
   };
 }
 
@@ -95,6 +98,11 @@ export function appendPressureHistoryRecord(records: PressureHistoryRecord[], ne
   }
 
   return [...safeRecords, nextRecord].slice(-MAX_HISTORY_RECORDS);
+}
+
+export function replaceTaskDerivedPressureHistory(records: PressureHistoryRecord[], nextRecord: PressureHistoryRecord): PressureHistoryRecord[] {
+  const preservedRecords = normalizePressureHistory(records).filter((record) => record.source !== 'task_derived');
+  return appendPressureHistoryRecord(preservedRecords, { ...nextRecord, source: 'task_derived' });
 }
 
 export function summarizePressureHistory(records: PressureHistoryRecord[], now = new Date()) {


### PR DESCRIPTION
### Motivation
- Persist and sync the Social graph and its layout version with cloud profile data to restore user social layout across devices.
- Make task-derived pressure history easier to maintain by distinguishing manual vs task-derived records and enabling safe recalculation when tasks change.
- Preserve explicit task completion timestamps and allow restoring archived tasks so edits and restores keep accurate timelines.
- Improve UIs for roadmap, priority map, activity log and data center to support new actions (edit/restore/recalculate) and mobile interactions.

### Description
- Cloud sync: include `socialNodes` and `socialLayoutVersion` in `CloudData`, `loadCloudData`, and `saveCloudProfile` to persist social graph and layout version.
- App state: add `socialNodes` and `socialLayoutVersion` local storage, merge cloud social data on login, and pass them into `SocialPage`; propagate dependencies in profile save effect.
- Pressure history: extend `PressureHistoryRecord` with `source`, set sensible defaults in `createPressureHistoryRecord`, add `replaceTaskDerivedPressureHistory` to preserve manual records while replacing task-derived points, and wire up `recalculateTaskDerivedPressureHistory` in the app to run after task edits/archives/deletes/restores.
- Tasks and timestamps: carry `completedAt` through `TaskInput`, `TaskForm`, `normalizeTaskInput`, and `normalizeStoredTask` to preserve and accept explicit completion times; add `restoreTask` to reactivate archived tasks.
- UI/UX: refactor `SocialPage` to accept stored nodes and setters from `App`; enhance `LogPage` to render richer AI artifact summaries and expose `onRecalculatePressureHistory`, `onEdit`, and `onRestore`; extend `ActivityLog` to support edit/restore buttons; update `PriorityMap` with clustering for mobile, task detail actions (edit/complete/delete), and a top-5 list for small screens; improve `GoalRoadmapPanel` parsing and rendering of structured stages; simplify `AITaskCommandBar` by removing raw JSON copy UI.

### Testing
- Ran static type check with `tsc` and found no type errors; the run completed successfully.
- Executed linting (`npm run lint`) and fixed reported issues; lint passed.
- Built the app (`npm run build`) and ran the test suite (`npm test`); both build and tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c2c84d1bc832cb30984dac3c23cfa)