### PR TITLE
精简档案页：去重/折叠重复压力快照并中文化可见文案

### DIFF
--- a/src/components/LogPage.tsx
+++ b/src/components/LogPage.tsx
@@ -26,7 +26,8 @@ interface DataCenterProps {
 }
 
 type DataTab = 'overview' | 'tasks' | 'pressure' | 'life' | 'health' | 'trends' | 'ai';
-type TimelineEvent = { id: string; timestamp: string; type: 'ai' | 'pressure' | 'task' | 'achievement' | 'overdue' | 'emotion'; title: string; body: string; tone: string };
+type TimelineEventType = 'weekly' | 'ai' | 'roadmap' | 'pressure' | 'task' | 'achievement' | 'overdue' | 'emotion' | 'manual' | 'behavior';
+type TimelineEvent = { id: string; timestamp: string; type: TimelineEventType; title: string; body: string; tone: string; hiddenByDefault?: boolean; duplicateCount?: number };
 
 const tabs: { id: DataTab; label: string; description: string }[] = [
   { id: 'overview', label: '总览', description: '生命状态总览' },
@@ -40,18 +41,40 @@ const tabs: { id: DataTab; label: string; description: string }[] = [
 
 
 const eventTypeLabels: Record<TimelineEvent['type'], string> = {
-  ai: 'AI',
-  pressure: '压力',
+  weekly: '周总结',
+  ai: 'AI 报告',
+  roadmap: '路线图',
+  pressure: '重要状态',
   task: '任务',
   achievement: '成就',
   overdue: '逾期',
   emotion: '情绪',
+  manual: '手动保存',
+  behavior: '行为信号',
 };
 
 function formatTime(value: string): string {
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) return '未知时间';
   return new Intl.DateTimeFormat('zh-CN', { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' }).format(date);
+}
+
+function localizeVisibleText(text: string): string {
+  return text
+    .replace(/\bdeadlines\b/gi, '截止时间')
+    .replace(/\bdeadline\b/gi, '截止时间')
+    .replace(/\bsnapshots\b/gi, '快照')
+    .replace(/\bsnapshot\b/gi, '快照')
+    .replace(/\barchives\b/gi, '档案')
+    .replace(/\barchive\b/gi, '档案')
+    .replace(/\breports\b/gi, '报告')
+    .replace(/\breport\b/gi, '报告')
+    .replace(/\bstatuses\b/gi, '状态')
+    .replace(/\bstatus\b/gi, '状态')
+    .replace(/\bgoals\b/gi, '目标')
+    .replace(/\bgoal\b/gi, '目标')
+    .replace(/\btasks\b/gi, '任务')
+    .replace(/\btask\b/gi, '任务');
 }
 
 function getPressureMood(pressure: number): string {
@@ -79,47 +102,138 @@ function getTaskIntakeDrafts(artifact: AIArtifact): { drafts?: TaskInput[]; note
 }
 
 function getAIArtifactSummary(artifact: AIArtifact): string {
-  if (artifact.kind !== 'task-intake') return `${artifact.content.slice(0, 180)}${artifact.content.length > 180 ? '…' : ''}`;
+  if (artifact.kind !== 'task-intake') return localizeVisibleText(`${artifact.content.slice(0, 180)}${artifact.content.length > 180 ? '…' : ''}`);
   const result = getTaskIntakeDrafts(artifact);
   if (result.error) return result.error;
-  if (!result.drafts?.length) return result.notes || '没有识别到明确任务。';
-  return `整理出 ${result.drafts.length} 个任务草稿：${result.drafts.slice(0, 3).map((draft) => draft.title).join('、')}${result.drafts.length > 3 ? '…' : ''}`;
+  if (!result.drafts?.length) return localizeVisibleText(result.notes || '没有识别到明确任务。');
+  return localizeVisibleText(`整理出 ${result.drafts.length} 个任务草稿：${result.drafts.slice(0, 3).map((draft) => draft.title).join('、')}${result.drafts.length > 3 ? '…' : ''}`);
 }
 
 function AIArtifactCard({ artifact }: { artifact: AIArtifact }) {
   const taskIntakeResult = artifact.kind === 'task-intake' ? getTaskIntakeDrafts(artifact) : undefined;
   return <article className="rounded-3xl bg-white/75 p-4 ring-1 ring-white/80">
-    <div className="flex flex-wrap items-center justify-between gap-2"><h3 className="font-semibold text-slate-950">{artifact.title}</h3><time className="text-xs text-slate-400">{formatTime(artifact.createdAt)}</time></div>
+    <div className="flex flex-wrap items-center justify-between gap-2"><h3 className="font-semibold text-slate-950">{localizeVisibleText(artifact.title)}</h3><time className="text-xs text-slate-400">{formatTime(artifact.createdAt)}</time></div>
     {taskIntakeResult ? taskIntakeResult.error ? <p className="mt-3 rounded-2xl bg-rose-50 px-3 py-2 text-sm font-semibold text-rose-600 ring-1 ring-rose-100">{taskIntakeResult.error}</p> : <div className="mt-3 grid gap-3 md:grid-cols-2">
-      {taskIntakeResult.notes ? <p className="text-sm leading-6 text-slate-500 md:col-span-2">{taskIntakeResult.notes}</p> : null}
+      {taskIntakeResult.notes ? <p className="text-sm leading-6 text-slate-500 md:col-span-2">{localizeVisibleText(taskIntakeResult.notes)}</p> : null}
       {taskIntakeResult.drafts?.length ? taskIntakeResult.drafts.map((draft, index) => <section key={`${draft.title}-${index}`} className="min-w-0 rounded-2xl bg-slate-50/80 p-3 ring-1 ring-slate-100">
-        <h4 className="font-semibold text-slate-900">{draft.title}</h4>
-        {draft.description ? <p className="mt-2 text-sm leading-6 text-slate-500">{draft.description}</p> : null}
+        <h4 className="font-semibold text-slate-900">{localizeVisibleText(draft.title)}</h4>
+        {draft.description ? <p className="mt-2 text-sm leading-6 text-slate-500">{localizeVisibleText(draft.description)}</p> : null}
         <div className="mt-3 flex flex-wrap gap-2 text-xs font-semibold text-slate-500"><span className="rounded-full bg-white px-2.5 py-1 ring-1 ring-slate-100">重要性 {draft.importance}/10</span><span className="rounded-full bg-white px-2.5 py-1 ring-1 ring-slate-100">截止 {formatDeadline(draft.deadline)}</span></div>
-        {draft.decomposition?.length ? <div className="mt-3"><p className="text-xs font-semibold text-slate-500">拆解步骤</p><ul className="mt-1 space-y-1 text-xs leading-5 text-slate-500">{draft.decomposition.slice(0, 5).map((item) => <li key={item}>· {item}</li>)}</ul></div> : null}
+        {draft.decomposition?.length ? <div className="mt-3"><p className="text-xs font-semibold text-slate-500">拆解步骤</p><ul className="mt-1 space-y-1 text-xs leading-5 text-slate-500">{draft.decomposition.slice(0, 5).map((item) => <li key={item}>· {localizeVisibleText(item)}</li>)}</ul></div> : null}
       </section>) : <p className="rounded-2xl border border-dashed border-slate-200 p-4 text-sm text-slate-400 md:col-span-2">没有识别到明确任务。</p>}
-    </div> : <p className="mt-2 whitespace-pre-wrap text-sm leading-6 text-slate-500">{artifact.content.slice(0, 360)}{artifact.content.length > 360 ? '…' : ''}</p>}
+    </div> : <p className="mt-2 whitespace-pre-wrap text-sm leading-6 text-slate-500">{localizeVisibleText(artifact.content.slice(0, 360))}{artifact.content.length > 360 ? '…' : ''}</p>}
   </article>;
 }
 
-function buildTimelineEvents(tasks: Task[], pressureHistory: PressureHistoryRecord[], achievements: Achievement[], aiArtifacts: AIArtifact[]): TimelineEvent[] {
-  const aiEvents: TimelineEvent[] = aiArtifacts.map((artifact) => ({ id: `ai-${artifact.id}`, timestamp: artifact.createdAt, type: 'ai', title: artifact.title, body: getAIArtifactSummary(artifact), tone: artifact.kind === 'goal-roadmap' ? 'bg-violet-50 text-violet-700 ring-violet-100' : 'bg-sky-50 text-sky-700 ring-sky-100' }));
-  const pressureEvents: TimelineEvent[] = pressureHistory.flatMap((record) => {
-    const events: TimelineEvent[] = [];
-    if (record.eventType === 'recalibration') events.push({ id: `pressure-recalibration-${record.id}`, timestamp: record.timestamp, type: 'pressure', title: '压力重新校准', body: record.note || `压力映射被重新写入，当前指数 ${record.pressure}。`, tone: 'bg-slate-50 text-slate-700 ring-slate-100' });
-    if (record.pressure > 100) events.push({ id: `pressure-spike-${record.id}`, timestamp: record.timestamp, type: 'pressure', title: '压力爆表', body: `压力值 ${record.pressure}。这不是失败，是系统记录到的一次高压状态。`, tone: 'bg-rose-50 text-rose-700 ring-rose-100' });
-    return events;
+const DEDUPE_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
+
+function toTimestamp(value: string): number {
+  const time = new Date(value).getTime();
+  return Number.isFinite(time) ? time : 0;
+}
+
+function getArtifactTimelineType(kind: AIArtifact['kind']): TimelineEvent['type'] {
+  if (kind === 'goal-roadmap') return 'roadmap';
+  if (kind === 'task-intake' || kind === 'recommendation') return 'behavior';
+  return 'ai';
+}
+
+function getArtifactTone(kind: AIArtifact['kind']): string {
+  if (kind === 'goal-roadmap') return 'bg-violet-50 text-violet-700 ring-violet-100';
+  if (kind === 'task-intake' || kind === 'recommendation') return 'bg-emerald-50 text-emerald-700 ring-emerald-100';
+  return 'bg-sky-50 text-sky-700 ring-sky-100';
+}
+
+function buildWeeklySummaryEvent(tasks: Task[], pressureHistory: PressureHistoryRecord[], aiArtifacts: AIArtifact[]): TimelineEvent | undefined {
+  const latestTimes = [
+    ...tasks.map((task) => toTimestamp(task.completedAt ?? task.abandonedAt ?? task.updatedAt)),
+    ...pressureHistory.map((record) => toTimestamp(record.timestamp)),
+    ...aiArtifacts.map((artifact) => toTimestamp(artifact.createdAt)),
+  ].filter(Boolean);
+  if (latestTimes.length === 0) return undefined;
+
+  const now = new Date(Math.max(...latestTimes));
+  const weekStart = now.getTime() - 7 * 24 * 60 * 60 * 1000;
+  const completed = tasks.filter((task) => task.completedAt && toTimestamp(task.completedAt) >= weekStart).length;
+  const abandoned = tasks.filter((task) => task.abandonedAt && toTimestamp(task.abandonedAt) >= weekStart).length;
+  const highPressure = pressureHistory.filter((record) => toTimestamp(record.timestamp) >= weekStart && record.pressure >= 81).length;
+  const aiCount = aiArtifacts.filter((artifact) => toTimestamp(artifact.createdAt) >= weekStart).length;
+  if (completed + abandoned + highPressure + aiCount === 0) return undefined;
+
+  return {
+    id: `weekly-${now.toISOString().slice(0, 10)}`,
+    timestamp: now.toISOString(),
+    type: 'weekly',
+    title: '近七日状态摘要',
+    body: `本周完成 ${completed} 项，放弃 ${abandoned} 项，出现 ${highPressure} 次高压/过载记录，新增 ${aiCount} 条 AI 观察。`,
+    tone: 'bg-indigo-50 text-indigo-700 ring-indigo-100',
+  };
+}
+
+function buildPressureEvents(pressureHistory: PressureHistoryRecord[]): TimelineEvent[] {
+  const sorted = [...pressureHistory].sort((left, right) => toTimestamp(left.timestamp) - toTimestamp(right.timestamp));
+  const events: TimelineEvent[] = [];
+  let previousMood = sorted[0] ? getPressureMood(sorted[0].pressure) : undefined;
+
+  sorted.forEach((record, index) => {
+    if (record.eventType === 'recalibration') {
+      events.push({ id: `pressure-recalibration-${record.id}`, timestamp: record.timestamp, type: 'pressure', title: '压力重新校准', body: localizeVisibleText(record.note || `压力映射被重新写入，当前指数 ${record.pressure}。`), tone: 'bg-slate-50 text-slate-700 ring-slate-100' });
+      return;
+    }
+
+    if (record.eventType === 'manual') {
+      events.push({ id: `pressure-manual-${record.id}`, timestamp: record.timestamp, type: 'manual', title: '用户手动保存状态', body: localizeVisibleText(record.note || `手动记录压力指数 ${record.pressure}。`), tone: 'bg-zinc-50 text-zinc-700 ring-zinc-100' });
+      return;
+    }
+
+    if (record.pressure > 100) {
+      events.push({ id: `pressure-spike-${record.id}`, timestamp: record.timestamp, type: 'pressure', title: '压力爆表', body: `压力值 ${record.pressure}。这不是失败，是系统记录到的一次高压状态。`, tone: 'bg-rose-50 text-rose-700 ring-rose-100' });
+      previousMood = getPressureMood(record.pressure);
+      return;
+    }
+
+    const mood = getPressureMood(record.pressure);
+    if (index > 0 && previousMood && mood !== previousMood) {
+      events.push({ id: `pressure-state-${record.id}`, timestamp: record.timestamp, type: 'pressure', title: '压力状态变化', body: `${previousMood} → ${mood}`, tone: 'bg-amber-50 text-amber-700 ring-amber-100' });
+    }
+    previousMood = mood;
   });
+
+  return events;
+}
+
+function foldRepeatedEvents(events: TimelineEvent[]): TimelineEvent[] {
+  const sorted = [...events].sort((left, right) => toTimestamp(right.timestamp) - toTimestamp(left.timestamp));
+  const visibleKeys = new Map<string, TimelineEvent>();
+
+  return sorted.map((event) => {
+    const key = `${event.type}|${event.title}|${event.body}`;
+    const latest = visibleKeys.get(key);
+    if (latest && Math.abs(toTimestamp(latest.timestamp) - toTimestamp(event.timestamp)) <= DEDUPE_WINDOW_MS) {
+      latest.duplicateCount = (latest.duplicateCount ?? 1) + 1;
+      return { ...event, hiddenByDefault: true };
+    }
+    visibleKeys.set(key, event);
+    return event;
+  });
+}
+
+function buildTimelineEvents(tasks: Task[], pressureHistory: PressureHistoryRecord[], achievements: Achievement[], aiArtifacts: AIArtifact[]): TimelineEvent[] {
+  const weeklyEvent = buildWeeklySummaryEvent(tasks, pressureHistory, aiArtifacts);
+  const aiEvents: TimelineEvent[] = aiArtifacts.map((artifact) => ({ id: `ai-${artifact.id}`, timestamp: artifact.createdAt, type: getArtifactTimelineType(artifact.kind), title: localizeVisibleText(artifact.title), body: getAIArtifactSummary(artifact), tone: getArtifactTone(artifact.kind) }));
+  const pressureEvents = buildPressureEvents(pressureHistory);
   const taskEvents: TimelineEvent[] = tasks.flatMap((task) => {
     const events: TimelineEvent[] = [];
-    if (task.completedAt) events.push({ id: `task-completed-${task.id}`, timestamp: task.completedAt, type: 'task', title: '任务闭环', body: task.title, tone: 'bg-emerald-50 text-emerald-700 ring-emerald-100' });
-    if (task.abandonedAt) events.push({ id: `task-abandoned-${task.id}`, timestamp: task.abandonedAt, type: 'task', title: '任务放弃', body: task.title, tone: 'bg-slate-50 text-slate-600 ring-slate-100' });
-    if (task.lifecycleStatus === 'active' && task.deadline && new Date(task.deadline).getTime() < Date.now()) events.push({ id: `task-overdue-${task.id}`, timestamp: task.deadline, type: 'overdue', title: '逾期事件', body: task.title, tone: 'bg-amber-50 text-amber-700 ring-amber-100' });
+    const taskName = localizeVisibleText(task.title);
+    if (task.reviewNote?.trim()) events.push({ id: `task-manual-${task.id}`, timestamp: task.completedAt ?? task.abandonedAt ?? task.updatedAt, type: 'manual', title: '用户手动保存档案', body: `${taskName}：${localizeVisibleText(task.reviewNote)}`, tone: 'bg-zinc-50 text-zinc-700 ring-zinc-100' });
+    else if (task.completedAt && task.importance >= 8) events.push({ id: `task-completed-${task.id}`, timestamp: task.completedAt, type: 'behavior', title: '关键任务闭环', body: taskName, tone: 'bg-emerald-50 text-emerald-700 ring-emerald-100' });
+    if (task.abandonedAt) events.push({ id: `task-abandoned-${task.id}`, timestamp: task.abandonedAt, type: 'behavior', title: '任务中止信号', body: taskName, tone: 'bg-slate-50 text-slate-600 ring-slate-100' });
+    if (task.lifecycleStatus === 'active' && task.deadline && new Date(task.deadline).getTime() < Date.now() && task.importance >= 7) events.push({ id: `task-overdue-${task.id}`, timestamp: task.deadline, type: 'overdue', title: '重要任务逾期', body: taskName, tone: 'bg-amber-50 text-amber-700 ring-amber-100' });
     return events;
   });
-  const achievementEvents: TimelineEvent[] = achievements.map((achievement) => ({ id: `achievement-${achievement.id}`, timestamp: achievement.unlockedAt, type: 'achievement', title: achievement.title, body: achievement.shortDescription, tone: 'bg-zinc-50 text-zinc-700 ring-zinc-100' }));
-  const emotionalEvents: TimelineEvent[] = pressureHistory.slice(-12).map((record) => ({ id: `emotion-${record.id}`, timestamp: record.timestamp, type: 'emotion', title: '情绪压力快照', body: getPressureMood(record.pressure), tone: 'bg-indigo-50 text-indigo-700 ring-indigo-100' }));
-  return [...aiEvents, ...pressureEvents, ...taskEvents, ...achievementEvents, ...emotionalEvents].sort((left, right) => new Date(right.timestamp).getTime() - new Date(left.timestamp).getTime()).slice(0, 80);
+  const achievementEvents: TimelineEvent[] = achievements.map((achievement) => ({ id: `achievement-${achievement.id}`, timestamp: achievement.unlockedAt, type: 'achievement', title: localizeVisibleText(achievement.title), body: localizeVisibleText(achievement.shortDescription), tone: 'bg-zinc-50 text-zinc-700 ring-zinc-100' }));
+  const emotionalEvents: TimelineEvent[] = pressureHistory.map((record) => ({ id: `emotion-${record.id}`, timestamp: record.timestamp, type: 'emotion', title: '折叠的情绪压力记录', body: getPressureMood(record.pressure), tone: 'bg-indigo-50 text-indigo-700 ring-indigo-100', hiddenByDefault: true }));
+  return foldRepeatedEvents([weeklyEvent, ...aiEvents, ...pressureEvents, ...taskEvents, ...achievementEvents, ...emotionalEvents].filter((event): event is TimelineEvent => Boolean(event))).slice(0, 120);
 }
 
 function StatCard({ label, value, detail, tone = 'from-white to-slate-50' }: { label: string; value: string | number; detail: string; tone?: string }) {
@@ -141,7 +255,11 @@ function Heatmap({ values }: { values: { date: string; count: number }[] }) {
 }
 
 function LifeTimeline({ events }: { events: TimelineEvent[] }) {
-  return <SectionShell eyebrow="档案" title="长期人类状态档案"><p className="max-w-2xl text-sm leading-6 text-slate-500">AI 报告、路线图、校准、闭环、逾期、行为信号和压力快照都会留在这里。统计不是数字，是行为镜像。</p>{events.length === 0 ? <div className="mt-5 rounded-3xl border border-dashed border-slate-200 bg-white/65 p-8 text-center text-sm text-slate-400">系统还没有足够的历史。开始记录任务、校准压力或生成 AI 报告后，这里会变成你的生活状态档案。</div> : <ol className="mt-6 space-y-3">{events.map((event) => <li key={event.id} className="grid gap-3 rounded-3xl bg-white/70 p-4 ring-1 ring-white/80 md:grid-cols-[9rem_1fr]"><time className="text-xs font-semibold text-slate-400">{formatTime(event.timestamp)}</time><div><div className="flex flex-wrap items-center gap-2"><span className={`rounded-full px-2.5 py-1 text-[11px] font-semibold ring-1 ${event.tone}`}>{eventTypeLabels[event.type]}</span><h3 className="font-semibold text-slate-950">{event.title}</h3></div><p className="mt-2 whitespace-pre-wrap text-sm leading-6 text-slate-500">{event.body}</p></div></li>)}</ol>}</SectionShell>;
+  const [showAllHistory, setShowAllHistory] = useState(false);
+  const visibleEvents = showAllHistory ? events : events.filter((event) => !event.hiddenByDefault);
+  const hiddenCount = events.length - visibleEvents.length;
+
+  return <SectionShell eyebrow="档案" title="长期人类状态档案"><p className="max-w-2xl text-sm leading-6 text-slate-500">这里只保留有信息增量的记录：周总结、重要状态变化、关键行为信号、AI 分析、目标路线图更新和用户手动保存的档案。低价值重复记录默认折叠，不再用连续压力记录刷屏。</p>{events.length === 0 ? <div className="mt-5 rounded-3xl border border-dashed border-slate-200 bg-white/65 p-8 text-center text-sm text-slate-400">系统还没有足够的历史。开始记录任务、校准压力或生成 AI 分析后，这里会变成你的生活状态档案。</div> : <><div className="mt-5 flex flex-wrap items-center justify-between gap-3 rounded-2xl bg-slate-50/80 px-4 py-3 text-xs text-slate-500 ring-1 ring-white/80"><span>已隐藏 {hiddenCount} 条重复或低信息量记录。</span>{hiddenCount > 0 ? <button type="button" onClick={() => setShowAllHistory((value) => !value)} className="rounded-full bg-white px-3 py-1.5 font-semibold text-slate-600 shadow-sm hover:bg-slate-100">{showAllHistory ? '收起低价值历史' : '展开全部历史'}</button> : null}</div><ol className="mt-6 space-y-3">{visibleEvents.map((event) => <li key={event.id} className={`grid gap-3 rounded-3xl bg-white/70 p-4 ring-1 ring-white/80 md:grid-cols-[9rem_1fr] ${event.hiddenByDefault ? 'opacity-75' : ''}`}><time className="text-xs font-semibold text-slate-400">{formatTime(event.timestamp)}</time><div><div className="flex flex-wrap items-center gap-2"><span className={`rounded-full px-2.5 py-1 text-[11px] font-semibold ring-1 ${event.tone}`}>{eventTypeLabels[event.type]}</span><h3 className="font-semibold text-slate-950">{event.title}</h3>{event.duplicateCount && event.duplicateCount > 1 ? <span className="rounded-full bg-slate-100 px-2 py-0.5 text-[11px] font-semibold text-slate-400">已合并 {event.duplicateCount} 条</span> : null}</div><p className="mt-2 whitespace-pre-wrap text-sm leading-6 text-slate-500">{event.body}</p></div></li>)}</ol></>}</SectionShell>;
 }
 
 export function LogPage({ tasks, goals, profile, pressure, pressureHistory, achievements, aiArtifacts, onAIReportGenerated, onRecalculatePressureHistory, onDelete, onEdit, onRestore, onReviewNoteChange }: DataCenterProps) {


### PR DESCRIPTION
### Motivation
- 避免档案页被连续压力/情绪快照刷屏，只保留对用户有信息增量的记录并折叠低价值重复项。 
- 统一档案页可见文本为中文，屏蔽英文 key/占位词但不改变底层数据结构。 

### Description
- 在 `src/components/LogPage.tsx` 中新增更丰富的 `TimelineEvent` 类型（包括 `weekly`/`roadmap`/`manual`/`behavior` 等）并为事件类型提供中文标签。 
- 增加 `localizeVisibleText` 函数以在渲染层将常见英文 key（如 `task`/`goal`/`status`/`report`/`archive`/`deadline`/`snapshot` 及复数形式）转换为中文展示而不修改存储数据。 
- 重写时间线构建逻辑 `buildTimelineEvents`：按优先级生成周总结、重要压力状态变化、AI 分析/路线图、关键行为信号、用户手动保存和重要逾期事件，并将连续短时间内同类型同内容记录按 7 天窗口合并/标记折叠，记录合并计数到 `duplicateCount`。 
- 在 `LifeTimeline` 展示层默认隐藏低价值重复记录并增加 `展开全部历史/收起低价值历史` 控件与合并计数显示，且保留当前视觉风格。 

### Testing
- 执行构建 `npm run build`，构建成功（生产打包通过）。 
- 使用 `rg` 检索和检查相关渲染文本词条（包括对英文 key 的匹配），确认可见展示已使用中文化函数处理（静态类型/变量名仍存在于代码中）。 
- 通过静态检查确认 `src/components/LogPage.tsx` 中对档案筛选、折叠与中文化逻辑已添加且类型兼容，运行时不会更改已有数据结构。 
- 说明：运行环境中无无头浏览器可用于截图级别的 UI 回归测试，因此未执行浏览器端的 E2E 截图验证。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a250662fbf0832cbb0c34355527195d)