### PR TITLE
feat: add multimodal task intake composer

### DIFF
--- a/api/intake.js
+++ b/api/intake.js
@@ -1,0 +1,78 @@
+const MAX_FILE_SIZE = 20 * 1024 * 1024;
+const BUCKET = 'intake-assets';
+const MIME_KINDS = new Map([
+  ['image/jpeg', 'image'], ['image/png', 'image'], ['image/gif', 'image'], ['image/webp', 'image'],
+  ['application/pdf', 'document'], ['application/vnd.openxmlformats-officedocument.wordprocessingml.document', 'document'],
+  ['text/plain', 'document'], ['text/markdown', 'document'], ['text/csv', 'document'],
+  ['application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', 'document'],
+  ['audio/webm', 'audio'], ['audio/ogg', 'audio'], ['audio/mp4', 'audio'], ['audio/mpeg', 'audio'],
+]);
+
+function send(response, status, body) {
+  response.statusCode = status;
+  response.setHeader('Content-Type', 'application/json; charset=utf-8');
+  response.end(JSON.stringify(body));
+}
+
+function env(...names) {
+  for (const name of names) if (process.env[name]) return process.env[name];
+  return '';
+}
+
+async function getUser(url, anonKey, token) {
+  const result = await fetch(`${url}/auth/v1/user`, { headers: { apikey: anonKey, Authorization: `Bearer ${token}` } });
+  return result.ok ? result.json() : null;
+}
+
+function parseRequest(body, userId) {
+  if (!body || typeof body !== 'object') throw new Error('请求体必须是 JSON 对象。');
+  const intakeId = typeof body.intakeId === 'string' && /^[0-9a-f-]{36}$/i.test(body.intakeId) ? body.intakeId : null;
+  const text = typeof body.text === 'string' ? body.text.trim().slice(0, 20_000) : '';
+  if (!intakeId || !Array.isArray(body.assets) || body.assets.length > 12) throw new Error('intakeId 或 assets 无效。');
+  const assets = body.assets.map((asset) => {
+    if (!asset || typeof asset !== 'object') throw new Error('附件结构无效。');
+    const expectedKind = MIME_KINDS.get(asset.mimeType);
+    if (!expectedKind || expectedKind !== asset.kind) throw new Error(`不支持附件类型：${asset.mimeType || 'unknown'}`);
+    if (!Number.isInteger(asset.size) || asset.size <= 0 || asset.size > MAX_FILE_SIZE) throw new Error('附件大小无效。');
+    if (typeof asset.fileName !== 'string' || !asset.fileName.trim() || asset.fileName.length > 255) throw new Error('附件名称无效。');
+    const prefix = `${userId}/${intakeId}/`;
+    if (typeof asset.storagePath !== 'string' || !asset.storagePath.startsWith(prefix) || asset.storagePath.includes('..')) throw new Error('附件不属于当前用户或当前录入。');
+    return { storagePath: asset.storagePath, kind: asset.kind, mimeType: asset.mimeType, fileName: asset.fileName, size: asset.size };
+  });
+  if (!text && !assets.length) throw new Error('请输入文本或添加附件。');
+  return { intakeId, text, assets };
+}
+
+async function verifyObject(url, anonKey, token, asset) {
+  const path = asset.storagePath.split('/').map(encodeURIComponent).join('/');
+  const result = await fetch(`${url}/storage/v1/object/info/${BUCKET}/${path}`, { headers: { apikey: anonKey, Authorization: `Bearer ${token}` } });
+  if (!result.ok) throw new Error(`找不到已上传附件：${asset.fileName}`);
+  const metadata = await result.json();
+  const actualSize = Number(metadata.metadata?.size ?? metadata.size);
+  const actualType = metadata.metadata?.mimetype ?? metadata.mimetype;
+  if (actualSize !== asset.size || actualType !== asset.mimeType) throw new Error(`附件元数据不匹配：${asset.fileName}`);
+}
+
+async function insert(url, anonKey, token, table, rows) {
+  const result = await fetch(`${url}/rest/v1/${table}`, { method: 'POST', headers: { apikey: anonKey, Authorization: `Bearer ${token}`, 'Content-Type': 'application/json', Prefer: 'return=minimal' }, body: JSON.stringify(rows) });
+  if (!result.ok) throw new Error(`保存 ${table} 失败：${await result.text()}`);
+}
+
+export default async function handler(request, response) {
+  if (request.method !== 'POST') return send(response, 405, { ok: false, error: '仅支持 POST。' });
+  try {
+    const url = env('SUPABASE_URL', 'VITE_SUPABASE_URL').replace(/\/+$/, '');
+    const anonKey = env('SUPABASE_ANON_KEY', 'VITE_SUPABASE_ANON_KEY');
+    const token = (request.headers.authorization || '').replace(/^Bearer\s+/i, '');
+    if (!url || !anonKey) return send(response, 500, { ok: false, error: '服务端 Supabase 未配置。' });
+    const user = token && await getUser(url, anonKey, token);
+    if (!user?.id) return send(response, 401, { ok: false, error: '登录状态无效或已过期。' });
+    const input = parseRequest(request.body, user.id);
+    await Promise.all(input.assets.map((asset) => verifyObject(url, anonKey, token, asset)));
+    await insert(url, anonKey, token, 'intake_messages', [{ id: input.intakeId, user_id: user.id, role: 'user', text_content: input.text, status: 'processing' }]);
+    if (input.assets.length) await insert(url, anonKey, token, 'intake_assets', input.assets.map((asset) => ({ id: crypto.randomUUID(), intake_message_id: input.intakeId, user_id: user.id, storage_bucket: BUCKET, storage_path: asset.storagePath, kind: asset.kind, mime_type: asset.mimeType, file_name: asset.fileName, size_bytes: asset.size, status: 'uploaded' })));
+    return send(response, 202, { ok: true, intakeId: input.intakeId, status: 'processing' });
+  } catch (error) {
+    return send(response, 400, { ok: false, error: error instanceof Error ? error.message : '录入请求无效。' });
+  }
+}

--- a/docs/MULTIMODAL_INTAKE.md
+++ b/docs/MULTIMODAL_INTAKE.md
@@ -1,0 +1,19 @@
+# 多模态任务录入实施说明
+
+## 审查结论
+
+- 当前应用是 Vite + React + TypeScript，而不是 Next.js；API 使用 Vercel 风格的 `api/*.js` 函数。
+- 原入口是 `AITaskCommandBar` 的单一 textarea。已有流程先解析为 `TaskInput[]`，再由用户点击“确认新增”调用上层回调，因此不会直接写入任务。
+- 正式任务字段以 `src/types/task.ts` 的 `Task` / `TaskInput` 为准；云端 `tasks` 表保存该结构的 JSONB，本迁移不修改它。
+- 项目自带轻量 Supabase REST/Auth 客户端，因而在其上补充 Storage object 上传/删除方法，而不引入第二套客户端。
+
+## 文件方案与阶段
+
+1. Composer 与上传：`MultimodalComposer.tsx`、`types/intake.ts`、`services/intakeStorage.ts`，以及 Supabase 客户端的 Storage 方法。
+2. 服务端接收与处理边界：`api/intake.js` 验证会话、路径所有权、MIME、大小及真实 Storage metadata；文件二进制不经过 API。
+3. Provider/Compiler：`services/aiProvider.ts` 集中定义图片、文档、语音和编译能力。具体异步提取器可以在 Worker 中实现，不散落进 UI。
+4. 草稿确认：保留既有确认面板；只有确认操作继续调用原 `onConfirmTasks`，`/api/intake` 只写 intake 表。
+
+## 数据库迁移
+
+迁移新增私有 `intake-assets` bucket、`intake_messages`、`intake_assets`、`task_drafts` 与按 `auth.uid()` 隔离的 RLS。它是增量迁移，不运行根目录会删除既有表的重建脚本，也不改变正式 `tasks` 表。部署时按时间戳顺序运行 `supabase/migrations` 中的 SQL。

--- a/src/components/AITaskCommandBar.tsx
+++ b/src/components/AITaskCommandBar.tsx
@@ -6,6 +6,9 @@ import { defaultAISettings, getAIConnectionLabel, isCloudAIAuthStateError, norma
 import type { AISettings } from '../services/aiClient';
 import { buildTaskIntakeUserPrompt, createTaskIntakePayload, parseTaskIntakeResponse, taskIntakeSystemPrompt } from '../services/taskIntakePrompt';
 import { getActivityTypeLabel } from '../utils/taskScoring';
+import { MultimodalComposer } from './MultimodalComposer';
+import type { MultimodalIntake } from '../types/intake';
+import { supabase } from '../lib/supabaseClient';
 
 interface AITaskCommandBarProps {
   tasks: Task[];
@@ -33,9 +36,9 @@ export function AITaskCommandBar({ tasks, onConfirmTasks, onAIArtifactGenerated 
   const [canResetAuthState, setCanResetAuthState] = useState(false);
 
 
-  async function structureTasks() {
-    const trimmedInput = input.trim();
-    if (!trimmedInput) {
+  async function structureTasks(intake?: MultimodalIntake) {
+    const trimmedInput = intake?.text.trim() || input.trim();
+    if (!trimmedInput && !intake?.assets.length) {
       setState('error');
       setCanResetAuthState(false);
       setErrorMessage('请先输入最近要做的事。');
@@ -48,7 +51,14 @@ export function AITaskCommandBar({ tasks, onConfirmTasks, onAIArtifactGenerated 
     setDrafts([]);
     setNotes('');
     try {
-      const payload = createTaskIntakePayload(trimmedInput, tasks);
+      if (intake?.assets.length) {
+        const session = await supabase.auth.getSession();
+        if (!session) throw new Error('请先登录后提交附件。');
+        const response = await fetch('/api/intake', { method: 'POST', headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${session.access_token}` }, body: JSON.stringify(intake) });
+        if (!response.ok) throw new Error((await response.json().catch(() => null))?.error || '附件处理请求失败。');
+      }
+      const sourceSummary = intake?.assets.length ? `${trimmedInput}\n\n附件：${intake.assets.map((asset) => asset.fileName).join('、')}` : trimmedInput;
+      const payload = createTaskIntakePayload(sourceSummary, tasks);
       const taskContext = tasks
         .filter((task) => task.lifecycleStatus === 'active')
         .slice(0, 30)
@@ -84,7 +94,7 @@ export function AITaskCommandBar({ tasks, onConfirmTasks, onAIArtifactGenerated 
   function confirmDrafts() {
     if (drafts.length === 0) return;
     onConfirmTasks(drafts);
-    setInput('');
+      setInput('');
     setDrafts([]);
     setNotes('');
     setCanResetAuthState(false);
@@ -116,16 +126,9 @@ export function AITaskCommandBar({ tasks, onConfirmTasks, onAIArtifactGenerated 
         <span className="rounded-full bg-slate-50 px-3 py-1.5 text-xs font-semibold text-slate-500 ring-1 ring-white/80">{getAIConnectionLabel(settings)}</span>
       </div>
 
-      <div className="mt-5 flex flex-col gap-3 lg:flex-row">
-        <textarea
-          value={input}
-          onChange={(event) => setInput(event.target.value)}
-          className="min-h-24 flex-1 rounded-[1.5rem] border border-slate-200/80 bg-white/85 px-4 py-3 text-sm leading-6 text-slate-700 outline-none placeholder:text-slate-400 focus:border-sky-200 focus:ring-4 focus:ring-sky-100/70"
-          placeholder="例如：这周五前交数学分析作业，今晚跑步，周末整理数据结构笔记。"
-        />
-        <button type="button" onClick={structureTasks} disabled={state === 'loading'} className="rounded-[1.5rem] bg-white/85 px-6 py-3 text-sm font-semibold text-slate-700 shadow-sm ring-1 ring-slate-200 hover:bg-slate-50 disabled:cursor-not-allowed disabled:text-slate-300 lg:w-36">
-          {state === 'loading' ? '整理中…' : '整理为任务'}
-        </button>
+      <div className="mt-5">
+        <MultimodalComposer disabled={state === 'loading'} onSubmit={structureTasks} placeholder="例如：这周五前交数学分析作业；也可以添加图片、文档或录音。" />
+        {state === 'loading' ? <p className="mt-2 text-xs font-semibold text-sky-600">正在验证附件并整理任务草稿，请勿重复提交…</p> : null}
       </div>
 
       {state === 'error' && errorMessage ? (

--- a/src/components/MultimodalComposer.tsx
+++ b/src/components/MultimodalComposer.tsx
@@ -1,0 +1,149 @@
+import { useEffect, useRef, useState } from 'react';
+import { ACCEPTED_INTAKE_TYPES, classifyIntakeFile, MAX_INTAKE_FILE_SIZE, removeIntakeFile, uploadIntakeFile } from '../services/intakeStorage';
+import type { IntakeAsset, MultimodalIntake } from '../types/intake';
+
+interface MultimodalComposerProps {
+  disabled?: boolean;
+  onSubmit: (intake: MultimodalIntake) => Promise<void> | void;
+  placeholder?: string;
+}
+
+function formatSize(bytes: number) {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
+}
+
+const statusLabels: Record<IntakeAsset['status'], string> = { queued: '排队中', uploading: '上传中', uploaded: '已上传', processing: '处理中', ready: '可用', error: '失败' };
+
+export function MultimodalComposer({ disabled = false, onSubmit, placeholder }: MultimodalComposerProps) {
+  const [text, setText] = useState('');
+  const [intakeId, setIntakeId] = useState(() => crypto.randomUUID());
+  const [assets, setAssets] = useState<IntakeAsset[]>([]);
+  const [dragging, setDragging] = useState(false);
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [recording, setRecording] = useState(false);
+  const [recordingSeconds, setRecordingSeconds] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const recorderRef = useRef<MediaRecorder | null>(null);
+  const chunksRef = useRef<Blob[]>([]);
+  const streamRef = useRef<MediaStream | null>(null);
+
+  useEffect(() => () => {
+    assets.forEach((asset) => asset.previewUrl && URL.revokeObjectURL(asset.previewUrl));
+    streamRef.current?.getTracks().forEach((track) => track.stop());
+  }, []); // Object URLs belong to this composer instance.
+
+  useEffect(() => {
+    if (!recording) return;
+    const timer = window.setInterval(() => setRecordingSeconds((value) => value + 1), 1000);
+    return () => window.clearInterval(timer);
+  }, [recording]);
+
+  function patchAsset(id: string, patch: Partial<IntakeAsset>) {
+    setAssets((current) => current.map((asset) => asset.id === id ? { ...asset, ...patch } : asset));
+  }
+
+  async function queueFiles(files: File[]) {
+    for (const file of files) {
+      const kind = classifyIntakeFile(file);
+      const id = crypto.randomUUID();
+      if (!kind || file.size > MAX_INTAKE_FILE_SIZE) {
+        setAssets((current) => [...current, { id, intakeId, kind: kind ?? 'document', fileName: file.name, mimeType: file.type || 'unknown', size: file.size, status: 'error', error: !kind ? '不支持此文件类型' : '文件不能超过 20 MB' }]);
+        continue;
+      }
+      const previewUrl = kind === 'image' ? URL.createObjectURL(file) : undefined;
+      const asset: IntakeAsset = { id, intakeId, kind, fileName: file.name, mimeType: file.type, size: file.size, status: 'queued', previewUrl, file };
+      setAssets((current) => [...current, asset]);
+      patchAsset(id, { status: 'uploading', progress: 0 });
+      try {
+        const storagePath = await uploadIntakeFile(file, intakeId, (progress) => patchAsset(id, { progress }));
+        patchAsset(id, { status: 'ready', storagePath, progress: 100, file: undefined });
+      } catch (error) {
+        patchAsset(id, { status: 'error', error: error instanceof Error ? error.message : '上传失败' });
+      }
+    }
+  }
+
+  async function deleteAsset(asset: IntakeAsset) {
+    if (asset.storagePath) await removeIntakeFile(asset.storagePath).catch(() => undefined);
+    if (asset.previewUrl) URL.revokeObjectURL(asset.previewUrl);
+    setAssets((current) => current.filter((item) => item.id !== asset.id));
+  }
+
+  async function retryAsset(asset: IntakeAsset) {
+    if (!asset.file) return deleteAsset(asset);
+    patchAsset(asset.id, { status: 'uploading', error: undefined });
+    try {
+      const storagePath = await uploadIntakeFile(asset.file, intakeId, (progress) => patchAsset(asset.id, { progress }));
+      patchAsset(asset.id, { status: 'ready', storagePath, progress: 100, file: undefined });
+    } catch (error) {
+      patchAsset(asset.id, { status: 'error', error: error instanceof Error ? error.message : '上传失败' });
+    }
+  }
+
+  async function startRecording() {
+    if (!navigator.mediaDevices?.getUserMedia || typeof MediaRecorder === 'undefined') return;
+    const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    const recorder = new MediaRecorder(stream);
+    streamRef.current = stream;
+    recorderRef.current = recorder;
+    chunksRef.current = [];
+    recorder.ondataavailable = (event) => event.data.size && chunksRef.current.push(event.data);
+    recorder.onstop = () => stream.getTracks().forEach((track) => track.stop());
+    setRecordingSeconds(0);
+    setRecording(true);
+    recorder.start();
+  }
+
+  function stopRecording(cancel = false) {
+    const recorder = recorderRef.current;
+    if (!recorder) return;
+    recorder.onstop = () => {
+      streamRef.current?.getTracks().forEach((track) => track.stop());
+      if (!cancel && chunksRef.current.length) {
+        const mimeType = recorder.mimeType || 'audio/webm';
+        const blob = new Blob(chunksRef.current, { type: mimeType });
+        void queueFiles([new File([blob], `录音-${new Date().toISOString().replace(/[:.]/g, '-')}.webm`, { type: mimeType.split(';')[0] })]);
+      }
+      chunksRef.current = [];
+    };
+    recorder.stop();
+    setRecording(false);
+  }
+
+  const busy = assets.some((asset) => ['queued', 'uploading', 'processing'].includes(asset.status));
+  const readyAssets = assets.filter((asset) => asset.status === 'ready' && asset.storagePath);
+  const canSubmit = !disabled && !busy && !recording && Boolean(text.trim() || readyAssets.length);
+
+  async function submit() {
+    if (!canSubmit) return;
+    await onSubmit({ intakeId, text: text.trim(), assets: readyAssets.map(({ storagePath, kind, mimeType, fileName, size }) => ({ storagePath: storagePath!, kind, mimeType, fileName, size })) });
+    setText('');
+    setAssets([]);
+    setIntakeId(crypto.randomUUID());
+  }
+
+  return <div className={`relative rounded-[1.5rem] border bg-white/90 transition ${dragging ? 'border-sky-400 ring-4 ring-sky-100' : 'border-slate-200/80'}`}
+    onDragOver={(event) => { event.preventDefault(); setDragging(true); }} onDragLeave={() => setDragging(false)} onDrop={(event) => { event.preventDefault(); setDragging(false); void queueFiles(Array.from(event.dataTransfer.files)); }}
+    onPaste={(event) => { const images = Array.from(event.clipboardData.files).filter((file) => file.type.startsWith('image/')); if (images.length) { event.preventDefault(); void queueFiles(images); } }}>
+    {assets.length ? <div className="grid gap-2 border-b border-slate-100 p-3 sm:grid-cols-2">
+      {assets.map((asset) => <div key={asset.id} className="flex min-w-0 items-center gap-3 rounded-xl bg-slate-50 p-2 ring-1 ring-slate-100">
+        {asset.previewUrl ? <img src={asset.previewUrl} alt="" className="h-12 w-12 shrink-0 rounded-lg object-cover" /> : <span className="grid h-12 w-12 shrink-0 place-items-center rounded-lg bg-white text-xl">{asset.kind === 'audio' ? '🎙' : '📄'}</span>}
+        <div className="min-w-0 flex-1"><p className="truncate text-xs font-semibold">{asset.fileName}</p><p className="mt-1 truncate text-[11px] text-slate-400">{asset.mimeType} · {formatSize(asset.size)}</p><p className={`mt-1 text-[11px] ${asset.status === 'error' ? 'text-rose-600' : 'text-sky-600'}`}>{asset.error || `${statusLabels[asset.status]}${asset.status === 'uploading' ? ` ${asset.progress ?? 0}%` : ''}`}</p></div>
+        {asset.status === 'error' && asset.file ? <button type="button" onClick={() => void retryAsset(asset)} className="text-xs text-sky-600">重试</button> : null}
+        <button type="button" aria-label={`删除 ${asset.fileName}`} onClick={() => void deleteAsset(asset)} className="grid h-8 w-8 shrink-0 place-items-center rounded-full text-slate-400 hover:bg-white">×</button>
+      </div>)}
+    </div> : null}
+    <textarea value={text} onChange={(event) => setText(event.target.value)} disabled={disabled} rows={3} className="min-h-28 w-full resize-none bg-transparent px-4 py-3 pb-14 text-sm leading-6 outline-none placeholder:text-slate-400" placeholder={placeholder || '描述任务，也可以添加图片、文档或录音…'} />
+    {dragging ? <div className="pointer-events-none absolute inset-0 grid place-items-center rounded-[1.5rem] bg-sky-50/90 text-sm font-semibold text-sky-700">松开以添加附件</div> : null}
+    <div className="absolute bottom-3 left-3 right-3 flex items-center justify-between">
+      <div className="relative"><button type="button" aria-label="添加附件" onClick={() => setMenuOpen((value) => !value)} disabled={disabled} className="grid h-9 w-9 place-items-center rounded-full bg-slate-100 text-xl text-slate-600 hover:bg-slate-200">+</button>
+        {menuOpen ? <div className="absolute bottom-11 left-0 z-10 w-44 rounded-xl bg-white p-1 text-sm shadow-xl ring-1 ring-slate-200"><button type="button" className="w-full rounded-lg px-3 py-2 text-left hover:bg-slate-50" onClick={() => { inputRef.current?.click(); setMenuOpen(false); }}>上传图片或文件</button></div> : null}
+        <input ref={inputRef} hidden multiple type="file" accept={ACCEPTED_INTAKE_TYPES} onChange={(event) => { void queueFiles(Array.from(event.target.files ?? [])); event.target.value = ''; }} />
+      </div>
+      {recording ? <div className="flex items-center gap-2 text-xs font-semibold text-rose-600"><span className="animate-pulse">● {String(Math.floor(recordingSeconds / 60)).padStart(2, '0')}:{String(recordingSeconds % 60).padStart(2, '0')}</span><button type="button" onClick={() => stopRecording(false)} className="rounded-full bg-rose-50 px-3 py-2">停止</button><button type="button" onClick={() => stopRecording(true)} className="px-2 py-2 text-slate-500">取消</button></div> : <div className="flex gap-2"><button type="button" aria-label="开始录音" onClick={() => void startRecording()} disabled={disabled || busy} className="grid h-9 w-9 place-items-center rounded-full text-slate-500 hover:bg-slate-100 disabled:opacity-40">🎙</button><button type="button" aria-label="提交" onClick={() => void submit()} disabled={!canSubmit} className="grid h-9 w-9 place-items-center rounded-full bg-slate-900 text-white disabled:bg-slate-200">↑</button></div>}
+    </div>
+    {busy ? <p className="absolute bottom-1 left-14 text-[10px] text-sky-600">附件上传或处理中，请稍候…</p> : null}
+  </div>;
+}

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -422,6 +422,26 @@ class VisualDeadlineSupabaseClient {
     return parseResponse<T>(await fetch(`${url}/rest/v1/${path}`, { ...init, headers }));
   }
 
+  async uploadStorageObject(bucket: string, path: string, file: Blob, session?: SupabaseSession | null): Promise<void> {
+    const { url, anonKey } = getRequiredConfig();
+    const activeSession = session ?? (await this.auth.getSession());
+    if (!activeSession) throw new Error('请先登录后上传附件。');
+    await parseResponse(await fetch(`${url}/storage/v1/object/${encodeURIComponent(bucket)}/${path.split('/').map(encodeURIComponent).join('/')}`, {
+      method: 'POST',
+      headers: { apikey: anonKey, Authorization: `Bearer ${activeSession.access_token}`, 'Content-Type': file.type || 'application/octet-stream', 'x-upsert': 'false' },
+      body: file,
+    }));
+  }
+
+  async removeStorageObject(bucket: string, path: string, session?: SupabaseSession | null): Promise<void> {
+    const { url, anonKey } = getRequiredConfig();
+    const activeSession = session ?? (await this.auth.getSession());
+    if (!activeSession) return;
+    await parseResponse(await fetch(`${url}/storage/v1/object/${encodeURIComponent(bucket)}/${path.split('/').map(encodeURIComponent).join('/')}`, {
+      method: 'DELETE', headers: { apikey: anonKey, Authorization: `Bearer ${activeSession.access_token}` },
+    }));
+  }
+
   private emit(session: SupabaseSession | null): void {
     this.listeners.forEach((listener) => {
       try {

--- a/src/services/aiProvider.ts
+++ b/src/services/aiProvider.ts
@@ -1,0 +1,40 @@
+import type { AISettings } from './aiClient';
+import { requestChatCompletion } from './aiClient';
+import type { IntakeAssetReference, TaskDraft } from '../types/intake';
+
+export interface AIProvider {
+  understandImage(asset: IntakeAssetReference, signal?: AbortSignal): Promise<string>;
+  extractDocument(asset: IntakeAssetReference, signal?: AbortSignal): Promise<string>;
+  transcribeAudio(asset: IntakeAssetReference, signal?: AbortSignal): Promise<string>;
+  compileTaskDrafts(input: string, signal?: AbortSignal): Promise<unknown>;
+}
+
+export class ConfiguredChatProvider implements AIProvider {
+  constructor(private readonly settings: AISettings) {}
+  understandImage(asset: IntakeAssetReference) { return this.unsupported('图像理解', asset); }
+  extractDocument(asset: IntakeAssetReference) { return this.unsupported('文档提取', asset); }
+  transcribeAudio(asset: IntakeAssetReference) { return this.unsupported('语音转写', asset); }
+  compileTaskDrafts(input: string) { return requestChatCompletion(this.settings, '将输入编译为 JSON 任务草稿。不要创建正式任务。', input).then(JSON.parse); }
+  private unsupported(capability: string, asset: IntakeAssetReference): Promise<string> {
+    return Promise.reject(new Error(`${capability} Provider 尚未配置：${asset.fileName}`));
+  }
+}
+
+export function validateTaskDraft(value: unknown): TaskDraft {
+  if (!value || typeof value !== 'object') throw new Error('TaskDraft 必须是对象。');
+  const item = value as Record<string, unknown>;
+  if (typeof item.title !== 'string' || !item.title.trim()) throw new Error('TaskDraft.title 无效。');
+  const importance = Number(item.importance);
+  const confidence = Number(item.confidence);
+  if (!Number.isFinite(importance) || importance < 1 || importance > 10 || !Number.isFinite(confidence) || confidence < 0 || confidence > 1) throw new Error('TaskDraft 评分无效。');
+  return { title: item.title.trim(), description: typeof item.description === 'string' ? item.description : undefined, projectId: typeof item.projectId === 'string' ? item.projectId : undefined, dueAt: typeof item.dueAt === 'string' ? item.dueAt : undefined, importance, estimatedMinutes: typeof item.estimatedMinutes === 'number' ? item.estimatedMinutes : undefined, subtasks: Array.isArray(item.subtasks) ? item.subtasks.filter((entry): entry is string => typeof entry === 'string') : [], sourceRefs: Array.isArray(item.sourceRefs) ? item.sourceRefs.filter((entry): entry is string => typeof entry === 'string') : [], confidence, ambiguities: Array.isArray(item.ambiguities) ? item.ambiguities.filter((entry): entry is string => typeof entry === 'string') : [] };
+}
+
+export class TaskCompiler {
+  constructor(private readonly provider: AIProvider) {}
+  async compile(input: { text: string; extractedContent: string[] }, signal?: AbortSignal): Promise<TaskDraft[]> {
+    const raw = await this.provider.compileTaskDrafts(JSON.stringify(input), signal);
+    if (!Array.isArray(raw)) throw new Error('AI 返回必须是 TaskDraft 数组。');
+    return raw.map(validateTaskDraft);
+  }
+}

--- a/src/services/intakeStorage.ts
+++ b/src/services/intakeStorage.ts
@@ -1,0 +1,41 @@
+import { supabase } from '../lib/supabaseClient';
+import type { IntakeAssetKind } from '../types/intake';
+
+export const INTAKE_BUCKET = 'intake-assets';
+export const MAX_INTAKE_FILE_SIZE = 20 * 1024 * 1024;
+
+const MIME_KINDS: Record<string, IntakeAssetKind> = {
+  'image/jpeg': 'image', 'image/png': 'image', 'image/gif': 'image', 'image/webp': 'image',
+  'application/pdf': 'document',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document': 'document',
+  'text/plain': 'document', 'text/markdown': 'document', 'text/csv': 'document',
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': 'document',
+  'audio/webm': 'audio', 'audio/ogg': 'audio', 'audio/mp4': 'audio', 'audio/mpeg': 'audio',
+};
+
+export const ACCEPTED_INTAKE_TYPES = Object.keys(MIME_KINDS).join(',');
+
+export function classifyIntakeFile(file: File): IntakeAssetKind | undefined {
+  return MIME_KINDS[file.type];
+}
+
+export function sanitizeFileName(fileName: string): string {
+  const normalized = fileName.normalize('NFKC').replace(/[^a-zA-Z0-9._-]+/g, '-').replace(/-+/g, '-');
+  return normalized.replace(/^[-.]+|[-.]+$/g, '').slice(0, 120) || 'attachment';
+}
+
+export async function uploadIntakeFile(file: File, intakeId: string, onProgress?: (progress: number) => void): Promise<string> {
+  const session = await supabase.auth.getSession();
+  if (!session) throw new Error('请先登录后上传附件。');
+  const path = `${session.user.id}/${intakeId}/${crypto.randomUUID()}-${sanitizeFileName(file.name)}`;
+  onProgress?.(10);
+  await supabase.uploadStorageObject(INTAKE_BUCKET, path, file, session);
+  onProgress?.(100);
+  return path;
+}
+
+export async function removeIntakeFile(path: string): Promise<void> {
+  const session = await supabase.auth.getSession();
+  if (!session) return;
+  await supabase.removeStorageObject(INTAKE_BUCKET, path, session);
+}

--- a/src/types/intake.ts
+++ b/src/types/intake.ts
@@ -1,0 +1,45 @@
+export type IntakeAssetStatus = 'queued' | 'uploading' | 'uploaded' | 'processing' | 'ready' | 'error';
+
+export type IntakeAssetKind = 'image' | 'document' | 'audio';
+
+export interface IntakeAsset {
+  id: string;
+  intakeId: string;
+  kind: IntakeAssetKind;
+  fileName: string;
+  mimeType: string;
+  size: number;
+  status: IntakeAssetStatus;
+  storagePath?: string;
+  previewUrl?: string;
+  progress?: number;
+  error?: string;
+  file?: File;
+}
+
+export interface IntakeAssetReference {
+  storagePath: string;
+  kind: IntakeAssetKind;
+  mimeType: string;
+  fileName: string;
+  size: number;
+}
+
+export interface MultimodalIntake {
+  intakeId: string;
+  text: string;
+  assets: IntakeAssetReference[];
+}
+
+export interface TaskDraft {
+  title: string;
+  description?: string;
+  projectId?: string;
+  dueAt?: string;
+  importance: number;
+  estimatedMinutes?: number;
+  subtasks: string[];
+  sourceRefs: string[];
+  confidence: number;
+  ambiguities: string[];
+}

--- a/supabase/migrations/20260726170000_multimodal_intake.sql
+++ b/supabase/migrations/20260726170000_multimodal_intake.sql
@@ -1,0 +1,77 @@
+-- Multimodal intake is deliberately separate from public.tasks: only a later,
+-- explicit confirmation flow may copy a task_draft into the existing task shape.
+begin;
+
+create table if not exists public.intake_messages (
+  id uuid primary key,
+  user_id uuid not null references auth.users(id) on delete cascade,
+  role text not null check (role in ('user', 'assistant', 'system')),
+  text_content text not null default '',
+  status text not null default 'processing' check (status in ('processing', 'ready', 'error', 'cancelled')),
+  error_message text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists public.intake_assets (
+  id uuid primary key,
+  intake_message_id uuid not null references public.intake_messages(id) on delete cascade,
+  user_id uuid not null references auth.users(id) on delete cascade,
+  storage_bucket text not null default 'intake-assets',
+  storage_path text not null unique,
+  kind text not null check (kind in ('image', 'document', 'audio')),
+  mime_type text not null,
+  file_name text not null,
+  size_bytes bigint not null check (size_bytes > 0 and size_bytes <= 20971520),
+  status text not null check (status in ('queued', 'uploading', 'uploaded', 'processing', 'ready', 'error')),
+  extracted_text text,
+  processing_error text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint intake_asset_path_owner check (split_part(storage_path, '/', 1) = user_id::text)
+);
+
+create table if not exists public.task_drafts (
+  id uuid primary key default gen_random_uuid(),
+  intake_message_id uuid not null references public.intake_messages(id) on delete cascade,
+  user_id uuid not null references auth.users(id) on delete cascade,
+  title text not null,
+  description text,
+  project_id text,
+  due_at timestamptz,
+  importance smallint not null check (importance between 1 and 10),
+  estimated_minutes integer check (estimated_minutes > 0),
+  subtasks jsonb not null default '[]'::jsonb,
+  source_refs jsonb not null default '[]'::jsonb,
+  confidence numeric(4,3) not null check (confidence between 0 and 1),
+  ambiguities jsonb not null default '[]'::jsonb,
+  status text not null default 'pending_confirmation' check (status in ('pending_confirmation', 'confirmed', 'rejected')),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists intake_messages_user_idx on public.intake_messages(user_id, created_at desc);
+create index if not exists intake_assets_message_idx on public.intake_assets(intake_message_id);
+create index if not exists task_drafts_message_idx on public.task_drafts(intake_message_id);
+
+alter table public.intake_messages enable row level security;
+alter table public.intake_assets enable row level security;
+alter table public.task_drafts enable row level security;
+
+do $$ declare table_name text; begin
+  foreach table_name in array array['intake_messages', 'intake_assets', 'task_drafts'] loop
+    execute format('drop policy if exists %I on public.%I', table_name || '_own_all', table_name);
+    execute format('create policy %I on public.%I for all to authenticated using (auth.uid() = user_id) with check (auth.uid() = user_id)', table_name || '_own_all', table_name);
+  end loop;
+end $$;
+
+insert into storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+values ('intake-assets', 'intake-assets', false, 20971520, array['image/jpeg','image/png','image/gif','image/webp','application/pdf','application/vnd.openxmlformats-officedocument.wordprocessingml.document','text/plain','text/markdown','text/csv','application/vnd.openxmlformats-officedocument.spreadsheetml.sheet','audio/webm','audio/ogg','audio/mp4','audio/mpeg'])
+on conflict (id) do update set public = false, file_size_limit = excluded.file_size_limit, allowed_mime_types = excluded.allowed_mime_types;
+
+drop policy if exists intake_storage_own_all on storage.objects;
+create policy intake_storage_own_all on storage.objects for all to authenticated
+using (bucket_id = 'intake-assets' and (storage.foldername(name))[1] = auth.uid()::text)
+with check (bucket_id = 'intake-assets' and (storage.foldername(name))[1] = auth.uid()::text);
+
+commit;


### PR DESCRIPTION
### Motivation

- 将原本单一的 AI 文本录入 textarea 升级为可复用的多模态 Composer，以支持文本、多图片/文档/音频上传、剪贴板粘贴、拖拽与浏览器录音，同时保留“自然语言 → 可确认任务草稿”的业务定位。 
- 要求浏览器直接把文件上载到 Supabase 私有 Storage（不经 API 中转），并约束 storage path、服务端验证与后续由 AI 编译为 TaskDraft 的架构边界。 
- 引入统一的数据结构与状态机（`IntakeAsset` / `IntakeAssetStatus`）和 AIProvider/TaskCompiler 抽象以便后续分阶段接入图像理解、文档抽取与语音转写。 

### Description

- 新增可复用组件 `MultimodalComposer`（`src/components/MultimodalComposer.tsx`），实现文本输入、多文件选择/拖拽、剪贴板图片粘贴、图片预览、上传进度、重试/删除、浏览器录音（实时时长、停止/取消），并在上传/处理期间禁止重复提交。 
- 新增类型定义 `src/types/intake.ts`，包含 `IntakeAsset`、`IntakeAssetReference`、`MultimodalIntake` 与 `TaskDraft`，以及状态枚举 `queued`/`uploading`/`uploaded`/`processing`/`ready`/`error`。 
- 新增客户端上传辅助 `src/services/intakeStorage.ts`，并在现有轻量 Supabase 客户端 `src/lib/supabaseClient.ts` 中扩展 `uploadStorageObject` 与 `removeStorageObject`，实现从浏览器直接上传到私有 bucket，路径格式为 `{userId}/{intakeId}/{uuid}-{sanitizedFileName}`。 
- 新增服务端元数据接口 `api/intake.js`，负责校验登录、附件归属、MIME 与大小，查询 Supabase Storage metadata 验证真实文件后写入 `intake_messages` 与 `intake_assets`（文件二进制不经 API 中转）。 
- 新增 AI 边界抽象 `src/services/aiProvider.ts`，包含 `AIProvider`、`ConfiguredChatProvider` 与 `TaskCompiler`，集中管理后续的图像理解、文档提取、语音转写与任务编译能力。 
- 修改现有 `AITaskCommandBar` 将原 textarea 替换为 `MultimodalComposer`，并在有附件时先调用 `/api/intake` 以记录 intake 元数据，随后仍使用现有 AI 编译与草稿确认流程；仅在用户确认后才会写入正式任务。 
- 新增非破坏性 Supabase 迁移 `supabase/migrations/20260726170000_multimodal_intake.sql`，创建 `intake_messages`、`intake_assets`、`task_drafts`、私有 `intake-assets` bucket、索引、约束与基于 `auth.uid()` 的 RLS 策略。 
- 增加实施说明文档 `docs/MULTIMODAL_INTAKE.md`，记录审查结论、分阶段实现方案与迁移指引。 

### Testing

- 成功构建与类型检查：运行 `npm run build` 与 `npx tsc -b --pretty false` 均通过。 
- 服务端文件语法检查：运行 `node --check api/intake.js` 通过且 `git diff --check` 没有问题。 
- 本地开发服务器能启动（`npm run dev -- --host 0.0.0.0` 可访问 Vite dev server），并已将变更提交为分支变更。 
- 已尝试运行 `npm run lint` 但仓库未定义 `lint` 脚本，尝试安装 `zod` 时因包注册表策略返回 HTTP 403 导致安装失败，故本次在 API/编译边界采用运行时校验而未引入不可用依赖。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a66444dbdf0832cafa77cf0c008a6af)