### PR TITLE
Add VD Billing v1 with Paddle-backed memberships

### DIFF
--- a/api/billing-checkout.js
+++ b/api/billing-checkout.js
@@ -1,0 +1,178 @@
+import crypto from 'node:crypto';
+
+const PLAN_CATALOG = {
+  vd_monthly: { amountMinor: 1900, currency: 'CNY', priceEnv: 'PADDLE_PRICE_MONTHLY' },
+  vd_yearly: { amountMinor: 19900, currency: 'CNY', priceEnv: 'PADDLE_PRICE_YEARLY' },
+};
+
+function send(response, status, body) {
+  response.statusCode = status;
+  response.setHeader('Content-Type', 'application/json; charset=utf-8');
+  response.setHeader('Cache-Control', 'no-store');
+  response.end(JSON.stringify(body));
+}
+
+function env(...names) {
+  for (const name of names) {
+    const value = process.env[name];
+    if (value) return value.trim();
+  }
+  return '';
+}
+
+function paddleBaseUrl() {
+  return env('PADDLE_ENVIRONMENT').toLowerCase() === 'production'
+    ? 'https://api.paddle.com'
+    : 'https://sandbox-api.paddle.com';
+}
+
+async function parseResponse(result) {
+  const text = await result.text();
+  let body = null;
+  if (text) {
+    try {
+      body = JSON.parse(text);
+    } catch {
+      body = { message: text.slice(0, 500) };
+    }
+  }
+  if (!result.ok) {
+    const detail = body?.error?.detail || body?.error?.code || body?.message || `HTTP ${result.status}`;
+    const error = new Error(String(detail));
+    error.status = result.status;
+    error.code = body?.error?.code;
+    throw error;
+  }
+  return body;
+}
+
+async function getUser(supabaseUrl, anonKey, token) {
+  const result = await fetch(`${supabaseUrl}/auth/v1/user`, {
+    headers: { apikey: anonKey, Authorization: `Bearer ${token}` },
+  });
+  if (!result.ok) return null;
+  return result.json();
+}
+
+async function serviceRest(supabaseUrl, serviceRoleKey, path, init = {}) {
+  const headers = new Headers(init.headers || {});
+  headers.set('apikey', serviceRoleKey);
+  headers.set('Authorization', `Bearer ${serviceRoleKey}`);
+  headers.set('Content-Type', 'application/json');
+  return parseResponse(await fetch(`${supabaseUrl}/rest/v1/${path}`, { ...init, headers }));
+}
+
+async function updateOrder(supabaseUrl, serviceRoleKey, orderId, patch) {
+  return serviceRest(supabaseUrl, serviceRoleKey, `billing_orders?id=eq.${encodeURIComponent(orderId)}`, {
+    method: 'PATCH',
+    headers: { Prefer: 'return=minimal' },
+    body: JSON.stringify(patch),
+  });
+}
+
+export default async function handler(request, response) {
+  if (request.method !== 'POST') return send(response, 405, { ok: false, error: '仅支持 POST。' });
+
+  const supabaseUrl = env('SUPABASE_URL', 'VITE_SUPABASE_URL').replace(/\/+$/, '');
+  const anonKey = env('SUPABASE_ANON_KEY', 'VITE_SUPABASE_ANON_KEY');
+  const serviceRoleKey = env('SUPABASE_SERVICE_ROLE_KEY');
+  const paddleApiKey = env('PADDLE_API_KEY');
+  const token = String(request.headers.authorization || '').replace(/^Bearer\s+/i, '');
+
+  if (!supabaseUrl || !anonKey || !serviceRoleKey) {
+    return send(response, 503, { ok: false, code: 'BILLING_STORAGE_NOT_CONFIGURED', error: '支付数据库尚未完成服务端配置。' });
+  }
+  if (!paddleApiKey) {
+    return send(response, 503, { ok: false, code: 'PADDLE_NOT_CONFIGURED', error: 'Paddle 尚未完成服务端配置。' });
+  }
+
+  const user = token ? await getUser(supabaseUrl, anonKey, token).catch(() => null) : null;
+  if (!user?.id) return send(response, 401, { ok: false, code: 'AUTH_REQUIRED', error: '请先登录 VD 后再开通会员。' });
+
+  const planCode = typeof request.body?.planCode === 'string' ? request.body.planCode : '';
+  const plan = PLAN_CATALOG[planCode];
+  if (!plan) return send(response, 400, { ok: false, code: 'INVALID_PLAN', error: '会员方案无效。' });
+
+  const priceId = env(plan.priceEnv);
+  if (!priceId) {
+    return send(response, 503, { ok: false, code: 'PADDLE_PRICE_NOT_CONFIGURED', error: '该会员方案尚未完成 Paddle 价格配置。' });
+  }
+
+  const orderId = crypto.randomUUID();
+  const createdAt = new Date().toISOString();
+
+  try {
+    await serviceRest(supabaseUrl, serviceRoleKey, 'billing_orders', {
+      method: 'POST',
+      headers: { Prefer: 'return=minimal' },
+      body: JSON.stringify([{
+        id: orderId,
+        user_id: user.id,
+        provider: 'paddle',
+        plan_code: planCode,
+        amount_minor: plan.amountMinor,
+        currency: plan.currency,
+        status: 'pending',
+        checkout_created_at: createdAt,
+      }]),
+    });
+  } catch (error) {
+    console.error('[VD_BILLING_ORDER_CREATE_FAILED]', { message: error instanceof Error ? error.message : String(error) });
+    return send(response, 503, { ok: false, code: 'BILLING_ORDER_CREATE_FAILED', error: '暂时无法建立支付订单，请稍后重试。' });
+  }
+
+  try {
+    const checkoutUrl = env('PADDLE_CHECKOUT_URL');
+    const payload = {
+      items: [{ price_id: priceId, quantity: 1 }],
+      collection_mode: 'automatic',
+      custom_data: {
+        vd_user_id: user.id,
+        vd_order_id: orderId,
+        vd_plan_code: planCode,
+      },
+      checkout: { url: checkoutUrl || null },
+    };
+
+    const paddleResult = await parseResponse(await fetch(`${paddleBaseUrl()}/transactions`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${paddleApiKey}`,
+        'Paddle-Version': '1',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+    }));
+
+    const transactionId = paddleResult?.data?.id;
+    if (typeof transactionId !== 'string' || !transactionId.startsWith('txn_')) {
+      throw new Error('Paddle 没有返回有效 transaction id。');
+    }
+
+    await updateOrder(supabaseUrl, serviceRoleKey, orderId, {
+      provider_transaction_id: transactionId,
+      provider_error_code: null,
+    });
+
+    return send(response, 201, {
+      ok: true,
+      orderId,
+      transactionId,
+      planCode,
+      amountMinor: plan.amountMinor,
+      currency: plan.currency,
+    });
+  } catch (error) {
+    const providerErrorCode = typeof error?.code === 'string' ? error.code.slice(0, 120) : 'paddle_transaction_create_failed';
+    await updateOrder(supabaseUrl, serviceRoleKey, orderId, {
+      status: 'failed',
+      provider_error_code: providerErrorCode,
+    }).catch(() => undefined);
+
+    console.error('[VD_PADDLE_TRANSACTION_CREATE_FAILED]', {
+      code: providerErrorCode,
+      message: error instanceof Error ? error.message : String(error),
+    });
+    return send(response, 502, { ok: false, code: 'PADDLE_TRANSACTION_CREATE_FAILED', error: 'Paddle 暂时无法创建支付，请稍后重试。' });
+  }
+}

--- a/api/billing-webhook.js
+++ b/api/billing-webhook.js
@@ -1,0 +1,256 @@
+import crypto from 'node:crypto';
+
+const SIGNATURE_TOLERANCE_SECONDS = 5;
+
+function send(response, status, body) {
+  response.statusCode = status;
+  response.setHeader('Content-Type', 'application/json; charset=utf-8');
+  response.setHeader('Cache-Control', 'no-store');
+  response.end(JSON.stringify(body));
+}
+
+function env(...names) {
+  for (const name of names) {
+    const value = process.env[name];
+    if (value) return value.trim();
+  }
+  return '';
+}
+
+async function readRawBody(request) {
+  const chunks = [];
+  for await (const chunk of request) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks).toString('utf8');
+}
+
+function verifyPaddleSignature(rawBody, signatureHeader, secret) {
+  if (!signatureHeader || typeof signatureHeader !== 'string' || !secret) return false;
+
+  const values = signatureHeader.split(';').reduce((result, part) => {
+    const separator = part.indexOf('=');
+    if (separator <= 0) return result;
+    const key = part.slice(0, separator).trim();
+    const value = part.slice(separator + 1).trim();
+    if (!result[key]) result[key] = [];
+    result[key].push(value);
+    return result;
+  }, {});
+
+  const timestamp = Number(values.ts?.[0]);
+  const signatures = values.h1 || [];
+  if (!Number.isFinite(timestamp) || !signatures.length) return false;
+  if (Math.abs(Math.floor(Date.now() / 1000) - timestamp) > SIGNATURE_TOLERANCE_SECONDS) return false;
+
+  const expected = crypto.createHmac('sha256', secret).update(`${timestamp}:${rawBody}`, 'utf8').digest('hex');
+  if (!/^[a-f0-9]{64}$/i.test(expected)) return false;
+  const expectedBuffer = Buffer.from(expected, 'hex');
+
+  return signatures.some((signature) => {
+    if (!/^[a-f0-9]{64}$/i.test(signature)) return false;
+    const signatureBuffer = Buffer.from(signature, 'hex');
+    return signatureBuffer.length === expectedBuffer.length && crypto.timingSafeEqual(signatureBuffer, expectedBuffer);
+  });
+}
+
+async function parseResponse(result) {
+  const text = await result.text();
+  let body = null;
+  if (text) {
+    try {
+      body = JSON.parse(text);
+    } catch {
+      body = { message: text.slice(0, 500) };
+    }
+  }
+  if (!result.ok) {
+    const detail = body?.message || body?.error || body?.hint || `HTTP ${result.status}`;
+    throw new Error(typeof detail === 'string' ? detail : JSON.stringify(detail));
+  }
+  return body;
+}
+
+async function serviceRest(supabaseUrl, serviceRoleKey, path, init = {}) {
+  const headers = new Headers(init.headers || {});
+  headers.set('apikey', serviceRoleKey);
+  headers.set('Authorization', `Bearer ${serviceRoleKey}`);
+  headers.set('Content-Type', 'application/json');
+  return parseResponse(await fetch(`${supabaseUrl}/rest/v1/${path}`, { ...init, headers }));
+}
+
+async function callRpc(supabaseUrl, serviceRoleKey, functionName, body) {
+  return serviceRest(supabaseUrl, serviceRoleKey, `rpc/${functionName}`, {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+}
+
+async function findOrderByTransaction(supabaseUrl, serviceRoleKey, transactionId) {
+  if (!transactionId) return null;
+  const rows = await serviceRest(
+    supabaseUrl,
+    serviceRoleKey,
+    `billing_orders?select=id,user_id,plan_code,status,amount_minor,currency&provider_transaction_id=eq.${encodeURIComponent(transactionId)}&limit=1`,
+  );
+  return Array.isArray(rows) ? rows[0] || null : null;
+}
+
+async function patchOrder(supabaseUrl, serviceRoleKey, orderId, patch) {
+  return serviceRest(supabaseUrl, serviceRoleKey, `billing_orders?id=eq.${encodeURIComponent(orderId)}`, {
+    method: 'PATCH',
+    headers: { Prefer: 'return=minimal' },
+    body: JSON.stringify(patch),
+  });
+}
+
+async function recordEvent(supabaseUrl, serviceRoleKey, event, transactionId, outcome) {
+  if (!event?.event_id) return;
+  await serviceRest(supabaseUrl, serviceRoleKey, 'billing_events?on_conflict=id', {
+    method: 'POST',
+    headers: { Prefer: 'resolution=ignore-duplicates,return=minimal' },
+    body: JSON.stringify([{
+      id: event.event_id,
+      provider: 'paddle',
+      event_type: String(event.event_type || 'unknown'),
+      provider_transaction_id: transactionId || null,
+      outcome,
+      occurred_at: event.occurred_at || null,
+    }]),
+  });
+}
+
+function priceToPlan(priceId) {
+  const monthly = env('PADDLE_PRICE_MONTHLY');
+  const yearly = env('PADDLE_PRICE_YEARLY');
+  if (monthly && priceId === monthly) return 'vd_monthly';
+  if (yearly && priceId === yearly) return 'vd_yearly';
+  return null;
+}
+
+function planFromCompletedTransaction(data) {
+  if (!Array.isArray(data?.items) || data.items.length !== 1) return null;
+  const item = data.items[0];
+  const priceId = item?.price?.id || item?.price_id;
+  return typeof priceId === 'string' ? priceToPlan(priceId) : null;
+}
+
+async function handleTransactionCompleted(supabaseUrl, serviceRoleKey, event) {
+  const data = event.data || {};
+  const transactionId = typeof data.id === 'string' ? data.id : '';
+  if (!transactionId) return { transactionId: null, outcome: 'ignored_missing_transaction' };
+
+  const order = await findOrderByTransaction(supabaseUrl, serviceRoleKey, transactionId);
+  if (!order) return { transactionId, outcome: 'ignored_unknown_order' };
+
+  const planCode = planFromCompletedTransaction(data);
+  if (!planCode || planCode !== order.plan_code) return { transactionId, outcome: 'ignored_price_mismatch' };
+  if (data.currency_code && data.currency_code !== 'CNY') return { transactionId, outcome: 'ignored_currency_mismatch' };
+
+  const customData = data.custom_data && typeof data.custom_data === 'object' ? data.custom_data : {};
+  if (customData.vd_order_id && customData.vd_order_id !== order.id) return { transactionId, outcome: 'ignored_order_metadata_mismatch' };
+  if (customData.vd_user_id && customData.vd_user_id !== order.user_id) return { transactionId, outcome: 'ignored_user_metadata_mismatch' };
+  if (customData.vd_plan_code && customData.vd_plan_code !== order.plan_code) return { transactionId, outcome: 'ignored_plan_metadata_mismatch' };
+
+  const paidAt = data.billed_at || data.updated_at || event.occurred_at || new Date().toISOString();
+  await patchOrder(supabaseUrl, serviceRoleKey, order.id, {
+    status: 'paid',
+    provider_customer_id: data.customer_id || null,
+    paid_at: paidAt,
+    provider_error_code: null,
+  });
+
+  await callRpc(supabaseUrl, serviceRoleKey, 'billing_apply_paddle_grant', {
+    p_user_id: order.user_id,
+    p_plan_code: order.plan_code,
+    p_order_id: order.id,
+    p_granted_at: paidAt,
+  });
+
+  return { transactionId, outcome: 'membership_granted' };
+}
+
+async function handleAdjustment(supabaseUrl, serviceRoleKey, event) {
+  const data = event.data || {};
+  const transactionId = typeof data.transaction_id === 'string' ? data.transaction_id : '';
+  if (!transactionId) return { transactionId: null, outcome: 'ignored_missing_transaction' };
+  if (data.action !== 'refund') return { transactionId, outcome: `ignored_adjustment_${String(data.action || 'unknown')}` };
+  if (data.status !== 'approved') return { transactionId, outcome: `refund_${String(data.status || 'unknown')}` };
+
+  const order = await findOrderByTransaction(supabaseUrl, serviceRoleKey, transactionId);
+  if (!order) return { transactionId, outcome: 'ignored_unknown_order' };
+
+  const refundedAt = data.updated_at || event.occurred_at || new Date().toISOString();
+  if (data.type === 'full') {
+    await patchOrder(supabaseUrl, serviceRoleKey, order.id, {
+      status: 'refunded',
+      refunded_at: refundedAt,
+    });
+    await callRpc(supabaseUrl, serviceRoleKey, 'billing_revoke_order_grant', {
+      p_order_id: order.id,
+      p_reason: 'approved_full_refund',
+      p_revoked_at: refundedAt,
+    });
+    return { transactionId, outcome: 'full_refund_membership_revoked' };
+  }
+
+  await patchOrder(supabaseUrl, serviceRoleKey, order.id, {
+    status: 'partially_refunded',
+    refunded_at: refundedAt,
+  });
+  return { transactionId, outcome: 'partial_refund_recorded' };
+}
+
+export default async function handler(request, response) {
+  if (request.method !== 'POST') return send(response, 405, { ok: false, error: '仅支持 POST。' });
+
+  const webhookSecret = env('PADDLE_WEBHOOK_SECRET');
+  const supabaseUrl = env('SUPABASE_URL', 'VITE_SUPABASE_URL').replace(/\/+$/, '');
+  const serviceRoleKey = env('SUPABASE_SERVICE_ROLE_KEY');
+  if (!webhookSecret || !supabaseUrl || !serviceRoleKey) {
+    return send(response, 503, { ok: false, code: 'BILLING_WEBHOOK_NOT_CONFIGURED', error: '支付回调尚未完成服务端配置。' });
+  }
+
+  const rawBody = await readRawBody(request);
+  const signatureHeader = request.headers['paddle-signature'];
+  if (!verifyPaddleSignature(rawBody, signatureHeader, webhookSecret)) {
+    return send(response, 401, { ok: false, code: 'INVALID_PADDLE_SIGNATURE', error: 'Paddle 回调签名无效。' });
+  }
+
+  let event;
+  try {
+    event = JSON.parse(rawBody);
+  } catch {
+    return send(response, 400, { ok: false, code: 'INVALID_WEBHOOK_JSON', error: 'Paddle 回调不是有效 JSON。' });
+  }
+
+  if (!event?.event_id || !event?.event_type) {
+    return send(response, 400, { ok: false, code: 'INVALID_WEBHOOK_EVENT', error: 'Paddle 回调缺少事件标识。' });
+  }
+
+  try {
+    let result = { transactionId: null, outcome: 'ignored_event_type' };
+    if (event.event_type === 'transaction.completed') {
+      result = await handleTransactionCompleted(supabaseUrl, serviceRoleKey, event);
+    } else if (event.event_type === 'adjustment.created' || event.event_type === 'adjustment.updated') {
+      result = await handleAdjustment(supabaseUrl, serviceRoleKey, event);
+    }
+
+    await recordEvent(supabaseUrl, serviceRoleKey, event, result.transactionId, result.outcome);
+    return send(response, 200, { ok: true, outcome: result.outcome });
+  } catch (error) {
+    console.error('[VD_PADDLE_WEBHOOK_FAILED]', {
+      eventId: event.event_id,
+      eventType: event.event_type,
+      message: error instanceof Error ? error.message : String(error),
+    });
+    // Non-2xx makes Paddle retry. All grant/revoke operations are idempotent.
+    return send(response, 500, { ok: false, code: 'WEBHOOK_PROCESSING_FAILED', error: '支付回调处理失败，将等待 Paddle 重试。' });
+  }
+}
+
+export const config = {
+  api: {
+    bodyParser: false,
+  },
+};

--- a/api/billing-webhook.js
+++ b/api/billing-webhook.js
@@ -143,6 +143,10 @@ async function handleTransactionCompleted(supabaseUrl, serviceRoleKey, event) {
   const order = await findOrderByTransaction(supabaseUrl, serviceRoleKey, transactionId);
   if (!order) return { transactionId, outcome: 'ignored_unknown_order' };
 
+  // A refund can be delivered before a delayed transaction.completed webhook. Never
+  // let an older payment event downgrade a final refunded state and re-grant access.
+  if (order.status === 'refunded') return { transactionId, outcome: 'ignored_completed_after_full_refund' };
+
   const planCode = planFromCompletedTransaction(data);
   if (!planCode || planCode !== order.plan_code) return { transactionId, outcome: 'ignored_price_mismatch' };
   if (data.currency_code && data.currency_code !== 'CNY') return { transactionId, outcome: 'ignored_currency_mismatch' };
@@ -154,7 +158,7 @@ async function handleTransactionCompleted(supabaseUrl, serviceRoleKey, event) {
 
   const paidAt = data.billed_at || data.updated_at || event.occurred_at || new Date().toISOString();
   await patchOrder(supabaseUrl, serviceRoleKey, order.id, {
-    status: 'paid',
+    status: order.status === 'partially_refunded' ? 'partially_refunded' : 'paid',
     provider_customer_id: data.customer_id || null,
     paid_at: paidAt,
     provider_error_code: null,
@@ -167,7 +171,7 @@ async function handleTransactionCompleted(supabaseUrl, serviceRoleKey, event) {
     p_granted_at: paidAt,
   });
 
-  return { transactionId, outcome: 'membership_granted' };
+  return { transactionId, outcome: order.status === 'partially_refunded' ? 'membership_granted_after_partial_refund' : 'membership_granted' };
 }
 
 async function handleAdjustment(supabaseUrl, serviceRoleKey, event) {

--- a/docs/BILLING_V1.md
+++ b/docs/BILLING_V1.md
@@ -1,0 +1,206 @@
+# VD Billing v1
+
+VD Billing v1 exists to prove one production loop:
+
+> signed-in VD user -> Paddle Checkout -> real payment -> verified webhook -> VD membership grant -> payment ledger -> payout to the seller.
+
+The provider is deliberately behind VD-owned order and membership records. Paddle can be replaced later without rewriting the membership model.
+
+## Frozen product rules
+
+| Plan | Price | Term | Renewal |
+| --- | ---: | --- | --- |
+| `vd_monthly` | CNY 19 | 1 natural month | one-time, no auto-renew |
+| `vd_yearly` | CNY 199 | 1 natural year | one-time, no auto-renew |
+
+- A user must be signed in before checkout can be created.
+- Re-purchase extends from the current membership end. It never discards remaining time.
+- A completed browser checkout does **not** grant membership.
+- Only a verified `transaction.completed` Paddle webhook grants membership.
+- A Paddle transaction can grant membership only once.
+- An approved full refund revokes the grant created by that order and rebuilds the remaining membership timeline.
+- An approved partial refund is recorded, but v1 does not automatically shorten membership time.
+- Admin grants are supported at the database/RPC layer without forging payment orders.
+
+## Architecture
+
+```text
+Browser
+  |
+  | authenticated POST /api/billing-checkout
+  v
+VD Vercel Function --------------------> Paddle API
+  |                                      |
+  | creates pending VD order             | transaction / checkout
+  v                                      v
+Supabase                              Customer pays
+  ^                                      |
+  |                                      | signed webhook
+  | POST /api/billing-webhook <----------+
+  |
+  +-- billing_orders
+  +-- membership_grants
+  +-- memberships
+  +-- billing_events
+```
+
+`billing_orders`, `membership_grants`, and `memberships` are VD-owned domain state. Paddle transaction/customer IDs are provider references, not primary membership state.
+
+## 1. Apply the Supabase migration
+
+Apply:
+
+```text
+supabase/migrations/20260823193000_billing_v1.sql
+```
+
+The migration adds:
+
+- `billing_orders`: user-visible order ledger;
+- `membership_grants`: immutable-ish entitlement grants with revocation metadata;
+- `memberships`: materialized current membership timeline;
+- `billing_events`: minimal webhook audit/idempotency record;
+- RLS so authenticated users can only read their own orders/membership;
+- service-role RPCs to grant, revoke, rebuild and manually grant membership.
+
+Do not expose `SUPABASE_SERVICE_ROLE_KEY` to the browser.
+
+## 2. Create Paddle catalog items
+
+Start in **Paddle Sandbox**.
+
+Create one VD membership product and two **one-time** CNY prices (their Paddle `billing_cycle` must be `null`):
+
+- monthly price: CNY 19.00 -> save its `pri_...` ID;
+- yearly price: CNY 199.00 -> save its `pri_...` ID.
+
+Configure pricing/tax display so checkout presents the intended consumer-facing CNY price. Do not create recurring monthly/yearly subscription prices for Billing v1.
+
+Also configure an approved/default Paddle checkout domain. For production the intended VD domain is `https://visualdeadline.com` (or `https://www.visualdeadline.com`, depending on the Paddle account's approved domain setup).
+
+## 3. Vercel environment variables
+
+### Server only — never prefix with `VITE_`
+
+```text
+SUPABASE_SERVICE_ROLE_KEY=...
+PADDLE_API_KEY=...
+PADDLE_WEBHOOK_SECRET=...
+PADDLE_PRICE_MONTHLY=pri_...
+PADDLE_PRICE_YEARLY=pri_...
+PADDLE_ENVIRONMENT=sandbox
+PADDLE_CHECKOUT_URL=https://visualdeadline.com
+```
+
+The existing server may already have:
+
+```text
+SUPABASE_URL=...
+SUPABASE_ANON_KEY=...
+```
+
+If not, the functions can fall back to the existing `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY`. The service-role key never has a browser fallback.
+
+### Browser-safe build variables
+
+```text
+VITE_PADDLE_CLIENT_TOKEN=test_...
+VITE_PADDLE_ENVIRONMENT=sandbox
+```
+
+Paddle client-side tokens are designed for Paddle.js. Paddle API keys and webhook secrets are not.
+
+Because `VITE_` values are compiled into the Vite build, redeploy after changing them.
+
+## 4. Paddle webhook destination
+
+Create a Paddle notification destination pointing to:
+
+```text
+https://visualdeadline.com/api/billing-webhook
+```
+
+Subscribe at minimum to:
+
+```text
+transaction.completed
+adjustment.created
+adjustment.updated
+```
+
+Copy that destination's secret into `PADDLE_WEBHOOK_SECRET`.
+
+The webhook handler:
+
+1. reads the raw request body;
+2. verifies `Paddle-Signature` using HMAC-SHA256;
+3. verifies that the completed transaction belongs to a server-created VD order;
+4. verifies that the Paddle price ID maps to the same VD plan;
+5. marks the order paid;
+6. calls an idempotent membership-grant RPC;
+7. records a minimal event audit row.
+
+## 5. Sandbox smoke test
+
+Do not call Billing v1 complete because the page renders. The sandbox acceptance test is:
+
+1. Apply the billing migration.
+2. Configure all Sandbox environment variables.
+3. Redeploy Vercel.
+4. Log into a real VD test account.
+5. Open **个人中心 -> 大会员**.
+6. Buy the CNY 19 monthly plan with Paddle Sandbox.
+7. Confirm the Paddle transaction reaches `completed`.
+8. Confirm `billing_orders.status = 'paid'`.
+9. Confirm exactly one `membership_grants` row references that order.
+10. Confirm `memberships.expires_at` is one natural month after the grant start.
+11. Replay/retry the same webhook and confirm the membership does not extend again.
+12. Buy the plan again and confirm the next month stacks after the existing expiry.
+13. Create an approved full refund and confirm the order becomes `refunded` and that order's grant is revoked.
+
+Then repeat with the CNY 199 yearly plan and confirm it adds 12 calendar months.
+
+## 6. Production cutover
+
+Only after Sandbox passes:
+
+1. Finish Paddle seller/KYC and website review.
+2. Create equivalent **live** CNY 19 / CNY 199 one-time prices.
+3. Create a live client-side token, API key and webhook destination.
+4. Change both Paddle environment variables to `production` and replace every Paddle ID/secret with live values.
+5. Redeploy.
+6. Use a real payer account to purchase one plan.
+7. Confirm VD grants membership from `transaction.completed` without manual intervention.
+8. Confirm the real transaction appears in Paddle balance.
+9. Later confirm Paddle payout reaches the configured payout account.
+
+The production acceptance condition is not merely “checkout opens.” It is:
+
+```text
+real money paid
+  -> Paddle transaction completed
+  -> signed webhook accepted
+  -> VD order paid
+  -> exactly one membership grant
+  -> membership visible to the user
+  -> funds visible in Paddle balance
+  -> payout eventually reconciled
+```
+
+## Security invariants
+
+- Never put `SUPABASE_SERVICE_ROLE_KEY`, `PADDLE_API_KEY`, or `PADDLE_WEBHOOK_SECRET` in GitHub source, browser storage, or `VITE_*` variables.
+- Never grant membership from a browser event such as `checkout.completed`.
+- Never trust a user-supplied amount or Paddle price ID. The checkout API accepts only VD plan codes and maps them server-side.
+- Never reconstruct a paid membership from an unknown Paddle transaction. The webhook only fulfills transactions already linked to a VD order.
+- Keep provider event payloads out of the long-term ledger unless a concrete audit need appears; v1 stores event IDs/type/outcome rather than raw payment payloads.
+
+## Provider exit path
+
+Future payment providers should implement the same domain operations:
+
+```text
+create order -> provider checkout -> verified provider event -> mark order paid -> create grant
+```
+
+A future `WechatPayAdapter`, `AlipayAdapter`, or other provider should not change how VD calculates membership periods or exposes entitlements.

--- a/src/components/LifeOSNav.tsx
+++ b/src/components/LifeOSNav.tsx
@@ -1,6 +1,10 @@
+import { useEffect, useState } from 'react';
 import { branding } from '../constants/branding';
+import { supabase } from '../lib/supabaseClient';
+import { getBillingSnapshot, isActiveMembership } from '../services/billing';
 import type { LifeOSModule, UserProfile } from '../types/task';
 import type { VDNotification } from '../types/notification';
+import { MembershipPanel } from './MembershipPanel';
 import { NotificationCenter } from './NotificationCenter';
 
 interface LifeOSNavProps {
@@ -49,87 +53,174 @@ function Avatar({ profile, size = 'md' }: { profile: UserProfile; size?: 'sm' | 
 export function LifeOSNav({ activeModule, profile, isSignedIn, isCloudLoading, syncStateLabel, onModuleChange, onOpenProfile, onSignIn, onSignOut, notifications, onMarkNotificationRead }: LifeOSNavProps) {
   const displayName = getDisplayName(profile);
   const username = getUsername(profile);
+  const [isMembershipOpen, setIsMembershipOpen] = useState(false);
+  const [isPlus, setIsPlus] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function refreshMembership() {
+      const session = await supabase.auth.getSession();
+      if (!session) {
+        if (!cancelled) setIsPlus(false);
+        return;
+      }
+      try {
+        const snapshot = await getBillingSnapshot(session);
+        if (!cancelled) setIsPlus(isActiveMembership(snapshot.membership));
+      } catch {
+        if (!cancelled) setIsPlus(false);
+      }
+    }
+
+    void refreshMembership();
+    const subscription = supabase.auth.onAuthStateChange(() => void refreshMembership());
+    const handleBillingRefresh = () => void refreshMembership();
+    window.addEventListener('vd:paddle-event', handleBillingRefresh);
+
+    return () => {
+      cancelled = true;
+      subscription.data.subscription.unsubscribe();
+      window.removeEventListener('vd:paddle-event', handleBillingRefresh);
+    };
+  }, []);
 
   return (
-    <header className="sticky top-2 z-30 overflow-visible rounded-[1.35rem] border border-white/70 bg-white/78 p-2 shadow-xl shadow-slate-200/60 backdrop-blur-xl transition-all duration-500 md:top-4 md:rounded-[2rem] md:p-3 md:shadow-2xl md:shadow-slate-200/70" aria-label="Visual Deadline 全局导航">
-      <div className="pointer-events-none absolute inset-x-8 top-0 h-px bg-gradient-to-r from-transparent via-white to-transparent" />
-      <div className="flex items-center justify-between gap-3 px-0.5 py-0.5 md:gap-4 md:px-2 md:py-1">
-        <button type="button" onClick={() => onModuleChange('home')} className="group flex min-w-0 items-center gap-2 rounded-[1.1rem] px-1.5 py-1 text-left transition duration-300 hover:bg-white/55 md:gap-3 md:rounded-[1.5rem] md:px-2 md:py-1.5">
-          <span className="flex h-9 w-9 items-center justify-center overflow-hidden rounded-xl bg-white shadow-md shadow-slate-300 ring-1 ring-slate-200/70 transition duration-300 group-hover:-translate-y-0.5 group-hover:shadow-xl md:h-12 md:w-12 md:rounded-2xl md:shadow-lg">
-            <img src="/logo.png" alt="Visual Deadline 标志" className="h-full w-full object-contain" />
-          </span>
-          <span className="min-w-0">
-            <span className="block truncate text-sm font-semibold tracking-tight text-slate-950 md:text-base">{branding.productName}</span>
-          </span>
-        </button>
-
-        <div className="flex shrink-0 items-start gap-1 md:pb-3"><NotificationCenter notifications={notifications} onMarkRead={onMarkNotificationRead} /><div className="group/avatar relative flex justify-end pr-0.5 md:pr-1" onMouseLeave={() => undefined}>
-          <button type="button" onClick={onOpenProfile} className="rounded-full outline-none transition duration-300 focus-visible:ring-4 focus-visible:ring-sky-100" aria-label="打开个人中心">
-            <Avatar profile={profile} />
+    <>
+      <header className="sticky top-2 z-30 overflow-visible rounded-[1.35rem] border border-white/70 bg-white/78 p-2 shadow-xl shadow-slate-200/60 backdrop-blur-xl transition-all duration-500 md:top-4 md:rounded-[2rem] md:p-3 md:shadow-2xl md:shadow-slate-200/70" aria-label="Visual Deadline 全局导航">
+        <div className="pointer-events-none absolute inset-x-8 top-0 h-px bg-gradient-to-r from-transparent via-white to-transparent" />
+        <div className="flex items-center justify-between gap-3 px-0.5 py-0.5 md:gap-4 md:px-2 md:py-1">
+          <button type="button" onClick={() => onModuleChange('home')} className="group flex min-w-0 items-center gap-2 rounded-[1.1rem] px-1.5 py-1 text-left transition duration-300 hover:bg-white/55 md:gap-3 md:rounded-[1.5rem] md:px-2 md:py-1.5">
+            <span className="flex h-9 w-9 items-center justify-center overflow-hidden rounded-xl bg-white shadow-md shadow-slate-300 ring-1 ring-slate-200/70 transition duration-300 group-hover:-translate-y-0.5 group-hover:shadow-xl md:h-12 md:w-12 md:rounded-2xl md:shadow-lg">
+              <img src="/logo.png" alt="Visual Deadline 标志" className="h-full w-full object-contain" />
+            </span>
+            <span className="min-w-0">
+              <span className="block truncate text-sm font-semibold tracking-tight text-slate-950 md:text-base">{branding.productName}</span>
+            </span>
           </button>
 
-          <div className="pointer-events-none absolute right-0 top-11 w-[min(18rem,calc(100vw-1.5rem))] translate-y-3 scale-[0.98] opacity-0 transition-all duration-300 ease-out group-hover/avatar:pointer-events-auto group-hover/avatar:translate-y-0 group-hover/avatar:scale-100 group-hover/avatar:opacity-100 group-focus-within/avatar:pointer-events-auto group-focus-within/avatar:translate-y-0 group-focus-within/avatar:scale-100 group-focus-within/avatar:opacity-100 md:top-[3.3rem] md:w-[18rem]">
-            <section className="overflow-hidden rounded-[1.75rem] border border-white/80 bg-white/92 p-4 shadow-2xl shadow-slate-300/70 ring-1 ring-slate-900/5 backdrop-blur-xl">
-              <div className="flex items-center gap-3">
-                <Avatar profile={profile} size="lg" />
-                <div className="min-w-0">
-                  <p className="truncate text-base font-semibold text-slate-950">{displayName}</p>
-                  <p className="mt-0.5 truncate text-sm text-slate-500">@{username}</p>
-                </div>
-              </div>
-
-              <div className="my-4 h-px bg-gradient-to-r from-transparent via-slate-200 to-transparent" />
-
-              <div className="space-y-1 text-sm font-medium text-slate-600">
-                <button type="button" onClick={onOpenProfile} className="flex w-full items-center justify-between rounded-2xl px-3 py-2.5 text-left transition duration-200 hover:bg-slate-50 hover:text-slate-950">
-                  个人中心 <span className="text-slate-300">⌘</span>
-                </button>
-                <button type="button" onClick={onOpenProfile} className="flex w-full items-center justify-between rounded-2xl px-3 py-2.5 text-left transition duration-200 hover:bg-slate-50 hover:text-slate-950">
-                  账号设置 <span className="text-slate-300">→</span>
-                </button>
-                <div className="rounded-2xl bg-slate-50/85 px-3 py-2.5 text-left">
-                  <p className="font-semibold text-slate-700">数据同步状态</p>
-                  <p className={`mt-1 text-xs leading-5 ${syncStateLabel.includes('失败') || syncStateLabel.includes('denied') ? 'text-rose-600' : 'text-slate-500'}`}>{syncStateLabel}</p>
-                </div>
-                <button type="button" onClick={onOpenProfile} className="flex w-full items-center justify-between rounded-2xl px-3 py-2.5 text-left transition duration-200 hover:bg-slate-50 hover:text-slate-950">
-                  安全与隐私 <span className="text-slate-300">→</span>
-                </button>
-              </div>
-
-              <div className="my-4 h-px bg-gradient-to-r from-transparent via-slate-200 to-transparent" />
-
-              {isSignedIn ? (
-                <button type="button" onClick={onSignOut} disabled={isCloudLoading} className="w-full rounded-2xl px-3 py-2.5 text-left text-sm font-semibold text-rose-500 transition duration-200 hover:bg-rose-50 disabled:cursor-not-allowed disabled:text-slate-300">
-                  退出登录
-                </button>
-              ) : (
-                <button type="button" onClick={onSignIn} className="w-full rounded-2xl bg-slate-950 px-3 py-2.5 text-center text-sm font-semibold text-white shadow-lg shadow-slate-200 transition duration-200 hover:-translate-y-0.5 hover:shadow-xl">
-                  登录同步
-                </button>
-              )}
-            </section>
-          </div>
-        </div></div>
-      </div>
-
-      <nav className="mt-2 hidden rounded-[1.45rem] bg-slate-100/65 p-1 md:block" aria-label="Visual Deadline 模块">
-        <div className="grid grid-cols-5 gap-1 sm:flex sm:flex-wrap">
-          {navItems.map((item) => {
-            const isActive = activeModule === item.id;
-            return (
-              <button
-                key={item.id}
-                type="button"
-                onClick={() => onModuleChange(item.id)}
-                className={`rounded-full px-3 py-2 text-sm font-semibold transition-all duration-300 ease-out md:px-4 ${isActive ? 'bg-white text-slate-950 shadow-sm shadow-slate-200' : 'text-slate-500 hover:-translate-y-0.5 hover:bg-white/65 hover:text-slate-700'}`}
-                aria-current={isActive ? 'page' : undefined}
-              >
-                {item.label}
+          <div className="flex shrink-0 items-center gap-2 md:pb-3">
+            <NotificationCenter notifications={notifications} onMarkRead={onMarkNotificationRead} />
+            <button
+              type="button"
+              onClick={() => setIsMembershipOpen(true)}
+              className={`rounded-full px-2.5 py-1 text-[11px] font-bold tracking-wide ring-1 transition hover:-translate-y-0.5 md:px-3 md:py-1.5 md:text-xs ${isPlus ? 'bg-slate-950 text-white ring-slate-900 shadow-md shadow-slate-300/50' : 'bg-white/85 text-slate-500 ring-slate-200 hover:bg-slate-50 hover:text-slate-800'}`}
+              aria-label={isPlus ? '管理 VD Plus' : '升级 VD Plus'}
+            >
+              {isPlus ? 'Plus' : 'Free'}
+            </button>
+            <div className="group/avatar relative flex justify-end pr-0.5 md:pr-1" onMouseLeave={() => undefined}>
+              <button type="button" onClick={onOpenProfile} className="rounded-full outline-none transition duration-300 focus-visible:ring-4 focus-visible:ring-sky-100" aria-label="打开个人中心">
+                <Avatar profile={profile} />
               </button>
-            );
-          })}
+
+              <div className="pointer-events-none absolute right-0 top-11 w-[min(18rem,calc(100vw-1.5rem))] translate-y-3 scale-[0.98] opacity-0 transition-all duration-300 ease-out group-hover/avatar:pointer-events-auto group-hover/avatar:translate-y-0 group-hover/avatar:scale-100 group-hover/avatar:opacity-100 group-focus-within/avatar:pointer-events-auto group-focus-within/avatar:translate-y-0 group-focus-within/avatar:scale-100 group-focus-within/avatar:opacity-100 md:top-[3.3rem] md:w-[18rem]">
+                <section className="overflow-hidden rounded-[1.75rem] border border-white/80 bg-white/92 p-4 shadow-2xl shadow-slate-300/70 ring-1 ring-slate-900/5 backdrop-blur-xl">
+                  <div className="flex items-center gap-3">
+                    <Avatar profile={profile} size="lg" />
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-center gap-2">
+                        <p className="truncate text-base font-semibold text-slate-950">{displayName}</p>
+                        <span className={`rounded-full px-2 py-0.5 text-[10px] font-bold ${isPlus ? 'bg-slate-950 text-white' : 'bg-slate-100 text-slate-500'}`}>{isPlus ? 'Plus' : 'Free'}</span>
+                      </div>
+                      <p className="mt-0.5 truncate text-sm text-slate-500">@{username}</p>
+                    </div>
+                  </div>
+
+                  <div className="my-4 h-px bg-gradient-to-r from-transparent via-slate-200 to-transparent" />
+
+                  <div className="space-y-1 text-sm font-medium text-slate-600">
+                    <button type="button" onClick={onOpenProfile} className="flex w-full items-center justify-between rounded-2xl px-3 py-2.5 text-left transition duration-200 hover:bg-slate-50 hover:text-slate-950">
+                      个人中心 <span className="text-slate-300">⌘</span>
+                    </button>
+                    <button type="button" onClick={() => setIsMembershipOpen(true)} className="flex w-full items-center justify-between rounded-2xl px-3 py-2.5 text-left transition duration-200 hover:bg-slate-50 hover:text-slate-950">
+                      {isPlus ? '管理 VD Plus' : '升级 VD Plus'} <span className="text-slate-300">→</span>
+                    </button>
+                    <button type="button" onClick={onOpenProfile} className="flex w-full items-center justify-between rounded-2xl px-3 py-2.5 text-left transition duration-200 hover:bg-slate-50 hover:text-slate-950">
+                      账号设置 <span className="text-slate-300">→</span>
+                    </button>
+                    <div className="rounded-2xl bg-slate-50/85 px-3 py-2.5 text-left">
+                      <p className="font-semibold text-slate-700">数据同步状态</p>
+                      <p className={`mt-1 text-xs leading-5 ${syncStateLabel.includes('失败') || syncStateLabel.includes('denied') ? 'text-rose-600' : 'text-slate-500'}`}>{syncStateLabel}</p>
+                    </div>
+                    <button type="button" onClick={onOpenProfile} className="flex w-full items-center justify-between rounded-2xl px-3 py-2.5 text-left transition duration-200 hover:bg-slate-50 hover:text-slate-950">
+                      安全与隐私 <span className="text-slate-300">→</span>
+                    </button>
+                  </div>
+
+                  <div className="my-4 h-px bg-gradient-to-r from-transparent via-slate-200 to-transparent" />
+
+                  {isSignedIn ? (
+                    <button type="button" onClick={onSignOut} disabled={isCloudLoading} className="w-full rounded-2xl px-3 py-2.5 text-left text-sm font-semibold text-rose-500 transition duration-200 hover:bg-rose-50 disabled:cursor-not-allowed disabled:text-slate-300">
+                      退出登录
+                    </button>
+                  ) : (
+                    <button type="button" onClick={onSignIn} className="w-full rounded-2xl bg-slate-950 px-3 py-2.5 text-center text-sm font-semibold text-white shadow-lg shadow-slate-200 transition duration-200 hover:-translate-y-0.5 hover:shadow-xl">
+                      登录同步
+                    </button>
+                  )}
+                </section>
+              </div>
+            </div>
+          </div>
         </div>
-      </nav>
-    </header>
+
+        <nav className="mt-2 hidden rounded-[1.45rem] bg-slate-100/65 p-1 md:block" aria-label="Visual Deadline 模块">
+          <div className="grid grid-cols-5 gap-1 sm:flex sm:flex-wrap">
+            {navItems.map((item) => {
+              const isActive = activeModule === item.id;
+              return (
+                <button
+                  key={item.id}
+                  type="button"
+                  onClick={() => onModuleChange(item.id)}
+                  className={`rounded-full px-3 py-2 text-sm font-semibold transition-all duration-300 ease-out md:px-4 ${isActive ? 'bg-white text-slate-950 shadow-sm shadow-slate-200' : 'text-slate-500 hover:-translate-y-0.5 hover:bg-white/65 hover:text-slate-700'}`}
+                  aria-current={isActive ? 'page' : undefined}
+                >
+                  {item.label}
+                </button>
+              );
+            })}
+          </div>
+        </nav>
+      </header>
+
+      {isMembershipOpen ? (
+        <div className="fixed inset-0 z-[180] overflow-y-auto bg-slate-950/95 px-4 py-8 text-white backdrop-blur-xl md:px-8 md:py-12" role="dialog" aria-modal="true" aria-label="升级 VD Plus">
+          <div className="mx-auto max-w-5xl">
+            <div className="mb-7 flex items-center justify-between gap-4">
+              <div>
+                <p className="text-sm font-semibold tracking-[0.24em] text-slate-500">VD MEMBERSHIP</p>
+                <h2 className="mt-2 text-3xl font-semibold tracking-tight text-white md:text-4xl">升级套餐</h2>
+                <p className="mt-2 text-sm text-slate-400">Free 保留基础体验；Plus 解锁会员身份，并作为后续高级功能的统一权限层。</p>
+              </div>
+              <button type="button" onClick={() => setIsMembershipOpen(false)} className="flex h-10 w-10 items-center justify-center rounded-full border border-white/10 bg-white/5 text-2xl font-light text-slate-400 transition hover:bg-white/10 hover:text-white" aria-label="关闭升级套餐">×</button>
+            </div>
+
+            <div className="grid gap-5 lg:grid-cols-[0.72fr_1.28fr]">
+              <section className="rounded-[2rem] border border-white/10 bg-white/[0.045] p-6 shadow-2xl shadow-black/20">
+                <div className="flex items-center justify-between gap-3">
+                  <h3 className="text-2xl font-semibold">Free</h3>
+                  {!isPlus ? <span className="rounded-full bg-white/10 px-3 py-1 text-xs font-semibold text-slate-300">当前套餐</span> : null}
+                </div>
+                <p className="mt-6 text-5xl font-semibold tracking-tight">¥0</p>
+                <p className="mt-2 text-sm text-slate-500">永久免费基础版</p>
+                <div className="my-6 h-px bg-white/10" />
+                <ul className="space-y-4 text-sm leading-6 text-slate-300">
+                  <li>✓ 任务、目标与压力可视化</li>
+                  <li>✓ 本地优先的数据管理</li>
+                  <li>✓ 登录后的基础云同步</li>
+                  <li>✓ 基础人生与数据模块</li>
+                </ul>
+              </section>
+
+              <div className="text-slate-900">
+                <MembershipPanel />
+              </div>
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </>
   );
 }

--- a/src/components/MembershipPanel.tsx
+++ b/src/components/MembershipPanel.tsx
@@ -1,0 +1,256 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { supabase, type SupabaseSession } from '../lib/supabaseClient';
+import {
+  BILLING_PLANS,
+  createBillingCheckout,
+  getBillingSnapshot,
+  getPlan,
+  isActiveMembership,
+  isPaddleClientConfigured,
+  openPaddleCheckout,
+  type BillingOrder,
+  type BillingPlanCode,
+  type BillingSnapshot,
+  type PaddleEvent,
+} from '../services/billing';
+
+const ORDER_STATUS_LABEL: Record<BillingOrder['status'], string> = {
+  pending: '等待支付',
+  paid: '已支付',
+  failed: '创建失败',
+  canceled: '已取消',
+  partially_refunded: '部分退款',
+  refunded: '已退款',
+};
+
+function formatDateTime(value: string | null | undefined): string {
+  if (!value) return '—';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return '—';
+  return new Intl.DateTimeFormat('zh-CN', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  }).format(date);
+}
+
+function formatAmount(order: BillingOrder): string {
+  return order.currency === 'CNY' ? `¥${(order.amount_minor / 100).toFixed(0)}` : `${order.amount_minor} ${order.currency}`;
+}
+
+function sleep(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => window.setTimeout(resolve, milliseconds));
+}
+
+export function MembershipPanel() {
+  const [session, setSession] = useState<SupabaseSession | null>(null);
+  const [snapshot, setSnapshot] = useState<BillingSnapshot>({ membership: null, orders: [] });
+  const [isLoading, setIsLoading] = useState(false);
+  const [buyingPlan, setBuyingPlan] = useState<BillingPlanCode | null>(null);
+  const [error, setError] = useState('');
+  const [message, setMessage] = useState('');
+  const pendingBaselineExpiry = useRef<string | null>(null);
+  const isMounted = useRef(true);
+
+  useEffect(() => {
+    isMounted.current = true;
+    let cancelled = false;
+
+    void supabase.auth.getSession().then((currentSession) => {
+      if (!cancelled) setSession(currentSession);
+    });
+    const subscription = supabase.auth.onAuthStateChange((nextSession) => setSession(nextSession));
+
+    return () => {
+      cancelled = true;
+      isMounted.current = false;
+      subscription.data.subscription.unsubscribe();
+    };
+  }, []);
+
+  const refresh = useCallback(async (activeSession = session): Promise<BillingSnapshot | null> => {
+    if (!activeSession) {
+      if (isMounted.current) setSnapshot({ membership: null, orders: [] });
+      return null;
+    }
+
+    setIsLoading(true);
+    setError('');
+    try {
+      const nextSnapshot = await getBillingSnapshot(activeSession);
+      if (isMounted.current) setSnapshot(nextSnapshot);
+      return nextSnapshot;
+    } catch (nextError) {
+      if (isMounted.current) setError(nextError instanceof Error ? nextError.message : '会员状态读取失败。');
+      return null;
+    } finally {
+      if (isMounted.current) setIsLoading(false);
+    }
+  }, [session]);
+
+  useEffect(() => {
+    if (!session) {
+      setSnapshot({ membership: null, orders: [] });
+      return;
+    }
+    void refresh(session);
+  }, [refresh, session]);
+
+  const waitForServerConfirmation = useCallback(async () => {
+    if (!session) return;
+    const baselineExpiry = pendingBaselineExpiry.current;
+
+    for (let attempt = 0; attempt < 15; attempt += 1) {
+      await sleep(2000);
+      const nextSnapshot = await refresh(session);
+      const nextExpiry = nextSnapshot?.membership?.expires_at ?? null;
+      if (nextSnapshot && nextExpiry && nextExpiry !== baselineExpiry) {
+        if (isMounted.current) {
+          setMessage(`会员已生效，有效期至 ${formatDateTime(nextExpiry)}。`);
+          setBuyingPlan(null);
+        }
+        pendingBaselineExpiry.current = nextExpiry;
+        return;
+      }
+    }
+
+    if (isMounted.current) {
+      setMessage('付款信息已经提交，但服务端仍在确认。Paddle 回调完成后会员会自动生效，你也可以稍后手动刷新。');
+      setBuyingPlan(null);
+    }
+  }, [refresh, session]);
+
+  useEffect(() => {
+    const handlePaddleEvent = (rawEvent: Event) => {
+      const event = rawEvent as CustomEvent<PaddleEvent>;
+      if (event.detail?.name !== 'checkout.completed') return;
+      setMessage('支付窗口已完成，正在等待 Paddle 服务端回调确认。');
+      void waitForServerConfirmation();
+    };
+
+    window.addEventListener('vd:paddle-event', handlePaddleEvent);
+    return () => window.removeEventListener('vd:paddle-event', handlePaddleEvent);
+  }, [waitForServerConfirmation]);
+
+  async function buy(planCode: BillingPlanCode) {
+    if (!session) {
+      setError('请先登录 VD 后再开通会员。');
+      return;
+    }
+    if (!isPaddleClientConfigured()) {
+      setError('支付前端尚未配置 Paddle Client-side Token。');
+      return;
+    }
+
+    setBuyingPlan(planCode);
+    setError('');
+    setMessage('正在建立安全支付订单…');
+    pendingBaselineExpiry.current = snapshot.membership?.expires_at ?? null;
+
+    try {
+      const checkout = await createBillingCheckout(planCode, session);
+      await openPaddleCheckout(checkout.transactionId, session.user.email);
+      setMessage('支付窗口已打开。只有 Paddle 服务端确认付款后，VD 才会授予会员时长。');
+    } catch (nextError) {
+      setBuyingPlan(null);
+      setError(nextError instanceof Error ? nextError.message : '支付窗口打开失败。');
+      setMessage('');
+    }
+  }
+
+  const membershipActive = isActiveMembership(snapshot.membership);
+  const membershipPlan = snapshot.membership ? getPlan(snapshot.membership.plan_code) : null;
+
+  return (
+    <section className="rounded-[2rem] border border-white/75 bg-white/80 p-5 shadow-xl shadow-slate-200/60 backdrop-blur md:p-6">
+      <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+        <div>
+          <p className="text-sm font-semibold tracking-[0.22em] text-slate-400">VD MEMBERSHIP</p>
+          <h2 className="mt-2 text-3xl font-semibold tracking-tight text-slate-950">大会员</h2>
+          <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-500">首版采用固定期限会员：一次购买一个自然月或一个自然年，不自动续费。支付与会员权限分离，Paddle 只是当前支付通道。</p>
+        </div>
+        <div className={`w-fit rounded-full px-4 py-2 text-sm font-semibold ring-1 ${membershipActive ? 'bg-emerald-50 text-emerald-700 ring-emerald-100' : 'bg-slate-50 text-slate-500 ring-slate-200'}`}>
+          {membershipActive ? `${membershipPlan?.label ?? '会员'} · 已生效` : '当前未开通'}
+        </div>
+      </div>
+
+      {membershipActive && snapshot.membership ? (
+        <div className="mt-5 rounded-3xl bg-emerald-50/70 p-4 ring-1 ring-emerald-100">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <div>
+              <p className="text-xs font-semibold tracking-[0.2em] text-emerald-600">会员有效期</p>
+              <p className="mt-2 text-lg font-semibold text-emerald-950">至 {formatDateTime(snapshot.membership.expires_at)}</p>
+            </div>
+            <p className="text-xs leading-5 text-emerald-700">再次购买会从当前有效期末尾继续累加，不会覆盖剩余时长。</p>
+          </div>
+        </div>
+      ) : null}
+
+      <div className="mt-5 grid gap-4 md:grid-cols-2">
+        {BILLING_PLANS.map((plan) => {
+          const isYearly = plan.code === 'vd_yearly';
+          const isBuying = buyingPlan === plan.code;
+          return (
+            <article key={plan.code} className={`relative rounded-[1.75rem] p-5 ring-1 ${isYearly ? 'bg-slate-950 text-white ring-slate-900' : 'bg-slate-50/85 text-slate-900 ring-white'}`}>
+              {isYearly ? <span className="absolute right-4 top-4 rounded-full bg-white/12 px-3 py-1 text-xs font-semibold text-white ring-1 ring-white/20">推荐</span> : null}
+              <p className={`text-sm font-semibold ${isYearly ? 'text-slate-300' : 'text-slate-500'}`}>{plan.label}</p>
+              <div className="mt-3 flex items-end gap-2">
+                <span className="text-4xl font-semibold tracking-tight">¥{plan.priceCny}</span>
+                <span className={`pb-1 text-sm ${isYearly ? 'text-slate-400' : 'text-slate-500'}`}>/ {plan.durationLabel}</span>
+              </div>
+              <p className={`mt-3 text-xs leading-5 ${isYearly ? 'text-slate-300' : 'text-slate-500'}`}>
+                {isYearly ? '相比连续购买 12 个月共 ¥228，年费节省 ¥29。' : '适合先体验完整会员身份与后续会员能力。'}
+              </p>
+              <button
+                type="button"
+                onClick={() => void buy(plan.code)}
+                disabled={!session || Boolean(buyingPlan)}
+                className={`mt-5 w-full rounded-full px-4 py-3 text-sm font-semibold transition disabled:cursor-not-allowed disabled:opacity-50 ${isYearly ? 'bg-white text-slate-950 hover:bg-slate-100' : 'bg-slate-950 text-white hover:bg-slate-800'}`}
+              >
+                {!session ? '登录后开通' : isBuying ? '正在建立订单…' : membershipActive ? `续费 ${plan.label}` : `开通 ${plan.label}`}
+              </button>
+            </article>
+          );
+        })}
+      </div>
+
+      {!isPaddleClientConfigured() ? (
+        <p className="mt-4 rounded-2xl bg-amber-50 px-4 py-3 text-xs leading-5 text-amber-700 ring-1 ring-amber-100">支付 UI 已接入，但当前部署还缺少 Paddle Client-side Token；完成环境变量配置后即可打开真实或 Sandbox Checkout。</p>
+      ) : null}
+      {message ? <p role="status" className="mt-4 rounded-2xl bg-sky-50 px-4 py-3 text-xs leading-5 text-sky-700 ring-1 ring-sky-100">{message}</p> : null}
+      {error ? <p role="alert" className="mt-4 rounded-2xl bg-rose-50 px-4 py-3 text-xs font-semibold leading-5 text-rose-700 ring-1 ring-rose-100">{error}</p> : null}
+
+      <div className="mt-6 flex flex-wrap items-center justify-between gap-3 border-t border-slate-100 pt-5">
+        <div>
+          <h3 className="text-sm font-semibold text-slate-800">支付与会员记录</h3>
+          <p className="mt-1 text-xs leading-5 text-slate-500">浏览器不能自行授予会员；只有经过签名验证的服务端支付事件可以改变会员状态。</p>
+        </div>
+        <button type="button" onClick={() => void refresh()} disabled={!session || isLoading} className="rounded-full bg-white px-4 py-2 text-xs font-semibold text-slate-600 ring-1 ring-slate-200 hover:bg-slate-50 disabled:opacity-50">
+          {isLoading ? '刷新中…' : '刷新会员状态'}
+        </button>
+      </div>
+
+      {session && snapshot.orders.length ? (
+        <div className="mt-4 overflow-hidden rounded-3xl ring-1 ring-slate-100">
+          {snapshot.orders.map((order, index) => (
+            <div key={order.id} className={`flex flex-col gap-2 bg-white/70 px-4 py-3 sm:flex-row sm:items-center sm:justify-between ${index ? 'border-t border-slate-100' : ''}`}>
+              <div>
+                <p className="text-sm font-semibold text-slate-800">{getPlan(order.plan_code).label} · {formatAmount(order)}</p>
+                <p className="mt-1 text-xs text-slate-400">{formatDateTime(order.created_at)} · {order.id.slice(0, 8)}</p>
+              </div>
+              <span className="w-fit rounded-full bg-slate-50 px-3 py-1 text-xs font-semibold text-slate-600 ring-1 ring-slate-100">{ORDER_STATUS_LABEL[order.status]}</span>
+            </div>
+          ))}
+        </div>
+      ) : session ? (
+        <p className="mt-4 rounded-2xl bg-slate-50/80 px-4 py-3 text-xs text-slate-500">暂无支付记录。</p>
+      ) : (
+        <p className="mt-4 rounded-2xl bg-slate-50/80 px-4 py-3 text-xs text-slate-500">登录后可以查看会员状态和自己的支付记录。</p>
+      )}
+
+      <p className="mt-5 text-xs leading-5 text-slate-400">购买即表示你已阅读并同意 <a href="/terms" className="font-semibold text-slate-600 underline decoration-slate-300 underline-offset-2">用户协议</a> 与 <a href="/privacy" className="font-semibold text-slate-600 underline decoration-slate-300 underline-offset-2">隐私政策</a>。退款申请按当前退款规则处理；获批的全额退款会撤销对应会员时长。</p>
+    </section>
+  );
+}

--- a/src/components/PrivacyPolicyPage.tsx
+++ b/src/components/PrivacyPolicyPage.tsx
@@ -20,46 +20,50 @@ const sections = [
         heading: '3. AI 相关数据',
         content: '当你使用 AI 功能时，我们可能会处理你主动输入的内容，用于任务分析、计划生成、压力评估、效率建议与功能优化。请不要主动输入身份证号、银行卡号、密码等敏感个人信息。',
       },
+      {
+        heading: '4. 会员与交易数据',
+        content: '当你购买 VD 会员时，我们会保存完成订单核对与会员授权所需的最少交易记录，例如 VD 订单号、会员方案、金额、币种、支付状态、第三方交易标识、支付与退款时间。银行卡号、支付密码等支付凭证由支付服务商处理，VD 不保存完整卡号或支付密码。',
+      },
     ],
   },
   {
     title: '二、我们如何使用你的信息',
     paragraphs: [
-      '我们收集的信息主要用于提供任务管理与云同步服务、优化产品体验、改进 AI 功能质量、保障账号与系统安全，以及进行统计分析与故障排查。',
+      '我们收集的信息主要用于提供任务管理与云同步服务、完成支付与会员授权、处理退款与交易核对、优化产品体验、改进 AI 功能质量、保障账号与系统安全，以及进行统计分析与故障排查。',
       '我们不会出售你的个人数据。',
     ],
   },
   {
     title: '三、数据存储与安全',
     paragraphs: [
-      'VD（Visual Deadline）会尽合理努力保护你的数据安全，包括加密传输、访问控制、服务端安全策略与日志审计。',
+      'VD（Visual Deadline）会尽合理努力保护你的数据安全，包括加密传输、访问控制、服务端安全策略与日志审计。支付结果由服务端验证的第三方回调确认，浏览器页面本身不能直接授予会员权限。',
       '但你应理解，互联网环境无法保证绝对安全。因网络故障、第三方服务异常、不可抗力或用户自身原因导致的数据风险，我们不承担超出法律规定范围之外的责任。',
     ],
   },
   {
     title: '四、Cookie 与本地存储',
     paragraphs: [
-      '为保障登录状态、提升使用体验与优化产品功能，VD（Visual Deadline）可能会使用 Cookie、LocalStorage、SessionStorage 与缓存数据。',
+      '为保障登录状态、提升使用体验与优化产品功能，VD（Visual Deadline）可能会使用 Cookie、LocalStorage、SessionStorage 与缓存数据。第三方支付页面也可能为完成支付、安全验证或风控使用其自身 Cookie 或类似技术。',
       '你可以通过浏览器设置清除相关数据。清除后，部分本地数据、登录状态或偏好设置可能无法恢复。',
     ],
   },
   {
     title: '五、第三方服务',
     paragraphs: [
-      'VD（Visual Deadline）当前或未来可能接入 Supabase、AI API 服务、云存储服务或数据分析服务。第三方服务可能依据其自身隐私政策处理部分数据。',
-      '我们会尽量只传输实现功能所需的数据，并持续评估第三方服务的数据安全与合规风险。',
+      'VD（Visual Deadline）当前或未来可能接入 Supabase、Paddle、AI API 服务、云存储服务或数据分析服务。Supabase 用于账号与云端数据能力；Paddle 当前用于处理会员付款、交易确认与退款等支付环节。第三方服务可能依据其自身隐私政策处理完成相应功能所必需的数据。',
+      '我们会尽量只传输实现功能所需的数据，并持续评估第三方服务的数据安全与合规风险。对于支付，VD 自己保存订单与会员状态，但不会主动保存完整银行卡号、支付密码等由支付服务商负责处理的支付凭证。',
     ],
   },
   {
     title: '六、你的权利',
     paragraphs: [
-      '你有权查看你的个人数据、修改账号信息、删除部分数据、申请注销账号，或停止使用本产品。部分功能未来可能通过产品内页面逐步开放。',
+      '你有权查看你的个人数据、修改账号信息、删除部分数据、申请注销账号，或停止使用本产品。涉及依法需要保留的交易、退款或安全记录时，我们可能在法定或合理必要期限内继续保存相应最少记录。部分功能未来可能通过产品内页面逐步开放。',
     ],
   },
   {
     title: '七、未成年人保护',
     paragraphs: [
-      '未成年人应在监护人同意与指导下使用 VD（Visual Deadline）。如果监护人发现未成年人未经同意提供个人信息，可联系我们处理。',
+      '未成年人应在监护人同意与指导下使用 VD（Visual Deadline），并应在监护人同意与指导下进行付费。如果监护人发现未成年人未经同意提供个人信息或发生付费，可联系我们处理。',
     ],
   },
   {
@@ -70,7 +74,7 @@ const sections = [
   },
   {
     title: '九、联系我们',
-    paragraphs: ['如你对本隐私政策有任何问题，可以通过 RanchoTao@gmail.com 联系我们。'],
+    paragraphs: ['如你对本隐私政策、会员或支付数据处理有任何问题，可以通过 RanchoTao@gmail.com 联系我们。'],
   },
 ];
 
@@ -82,7 +86,7 @@ export function PrivacyPolicyPage({ onBack }: PrivacyPolicyPageProps) {
           <div>
             <p className="text-sm font-semibold uppercase tracking-[0.24em] text-slate-400">VD（Visual Deadline）</p>
             <h1 className="mt-3 text-3xl font-semibold tracking-tight text-slate-950 md:text-5xl">隐私政策</h1>
-            <p className="mt-4 text-sm leading-6 text-slate-500">更新日期：2026年5月17日 · 生效日期：2026年5月17日</p>
+            <p className="mt-4 text-sm leading-6 text-slate-500">更新日期：2026年8月23日 · 生效日期：2026年8月23日</p>
           </div>
           <div className="flex flex-wrap gap-2">
             {onBack ? (
@@ -120,7 +124,7 @@ export function PrivacyPolicyPage({ onBack }: PrivacyPolicyPageProps) {
         </div>
 
         <footer className="mt-10 border-t border-slate-100 pt-6 text-sm leading-6 text-slate-500">
-          <p>VD（Visual Deadline）隐私政策 v1.0</p>
+          <p>VD（Visual Deadline）隐私政策 v1.1</p>
         </footer>
       </article>
     </main>

--- a/src/components/ProfilePage.tsx
+++ b/src/components/ProfilePage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState, type ChangeEvent } from 'react';
 import type { UserProfile } from '../types/task';
 import { DataSafetyPanel } from './DataSafetyPanel';
 import { DeveloperToolsPanel } from './DeveloperToolsPanel';
+import { MembershipPanel } from './MembershipPanel';
 import { uploadAvatar } from '../services/avatarStorage';
 
 interface ProfilePageProps {
@@ -104,6 +105,8 @@ export function ProfilePage({ profile, onProfileChange, isEmailVerified }: Profi
         ))}
       </div>
       </div>
+
+      <MembershipPanel />
 
       <section className="rounded-[2rem] border border-white/70 bg-white/75 p-5 shadow-xl shadow-slate-200/60 backdrop-blur">
         <p className="text-sm font-semibold text-slate-500">系统与隐私</p>

--- a/src/components/TermsPage.tsx
+++ b/src/components/TermsPage.tsx
@@ -47,10 +47,12 @@ const sections = [
     ],
   },
   {
-    title: '七、费用与服务变更',
+    title: '七、会员、支付与退款',
     paragraphs: [
-      '当前功能可能包含免费能力。未来如推出付费功能、订阅计划或额度限制，我们会在相关页面说明价格、权益与规则。',
-      '我们可能根据产品发展、技术调整、安全要求或法律法规变化，新增、修改、暂停或终止部分功能。重大变更会尽量通过产品页面或其他合理方式提示。',
+      'VD 当前提供月会员与年会员两种固定期限会员：月会员人民币 19 元，购买后增加 1 个自然月有效期；年会员人民币 199 元，购买后增加 1 个自然年有效期。两种方案均为一次性购买，不自动续费。已有有效会员再次购买时，新时长从当前有效期末尾继续累加。',
+      '会员支付当前由 Paddle 等第三方支付基础设施处理。支付方式、交易审核、税费展示、退款到账时间等环节可能同时受支付服务商、支付渠道和适用法律规则影响。VD 不会以浏览器页面显示“支付完成”作为开通依据，只有服务端确认支付成功后才会授予会员时长。',
+      '如发生重复扣款、明显支付错误或因 VD 系统问题导致已购买会员无法正常使用，可以联系我们处理。普通退款申请原则上可在购买后 7 日内提出，是否批准会结合会员使用情况、支付服务商规则和适用法律要求处理。获批的全额退款会撤销该笔订单对应的会员时长；部分退款按实际处理结果记录。',
+      '随着产品发展，我们可能调整会员价格、权益或支付方式。已经完成的订单及已授予会员时长不会仅因后续价格调整被追溯缩短；重大规则变更会尽量通过产品页面或其他合理方式提示。',
     ],
   },
   {
@@ -69,7 +71,7 @@ const sections = [
   },
   {
     title: '十、联系我们',
-    paragraphs: ['如你对本协议有任何问题，可以通过 RanchoTao@gmail.com 联系我们。'],
+    paragraphs: ['如你对本协议、会员或支付有任何问题，可以通过 RanchoTao@gmail.com 联系我们。'],
   },
 ];
 
@@ -81,7 +83,7 @@ export function TermsPage({ onBack }: TermsPageProps) {
           <div>
             <p className="text-sm font-semibold tracking-[0.24em] text-slate-400">VD（Visual Deadline）</p>
             <h1 className="mt-3 text-3xl font-semibold tracking-tight text-slate-950 md:text-5xl">用户协议</h1>
-            <p className="mt-4 text-sm leading-6 text-slate-500">更新日期：2026年5月17日 · 生效日期：2026年5月17日</p>
+            <p className="mt-4 text-sm leading-6 text-slate-500">更新日期：2026年8月23日 · 生效日期：2026年8月23日</p>
           </div>
           <div className="flex flex-wrap gap-2">
             {onBack ? (
@@ -109,7 +111,7 @@ export function TermsPage({ onBack }: TermsPageProps) {
         </div>
 
         <footer className="mt-10 border-t border-slate-100 pt-6 text-sm leading-6 text-slate-500">
-          <p>VD（Visual Deadline）用户协议 v1.0</p>
+          <p>VD（Visual Deadline）用户协议 v1.1</p>
         </footer>
       </article>
     </main>

--- a/src/services/billing.ts
+++ b/src/services/billing.ts
@@ -1,0 +1,218 @@
+import { supabase, type SupabaseSession } from '../lib/supabaseClient';
+
+export type BillingPlanCode = 'vd_monthly' | 'vd_yearly';
+export type BillingOrderStatus = 'pending' | 'paid' | 'failed' | 'canceled' | 'partially_refunded' | 'refunded';
+
+export interface BillingPlan {
+  code: BillingPlanCode;
+  label: string;
+  priceCny: number;
+  durationLabel: string;
+}
+
+export interface MembershipRecord {
+  user_id: string;
+  plan_code: BillingPlanCode;
+  starts_at: string;
+  expires_at: string;
+  source: 'paddle' | 'admin_grant';
+  updated_at: string;
+}
+
+export interface BillingOrder {
+  id: string;
+  plan_code: BillingPlanCode;
+  amount_minor: number;
+  currency: 'CNY';
+  status: BillingOrderStatus;
+  provider_transaction_id: string | null;
+  checkout_created_at: string;
+  paid_at: string | null;
+  refunded_at: string | null;
+  created_at: string;
+}
+
+export interface BillingSnapshot {
+  membership: MembershipRecord | null;
+  orders: BillingOrder[];
+}
+
+interface CheckoutResponse {
+  ok: boolean;
+  orderId: string;
+  transactionId: string;
+  planCode: BillingPlanCode;
+  amountMinor: number;
+  currency: 'CNY';
+}
+
+export interface PaddleEvent {
+  name?: string;
+  data?: unknown;
+}
+
+interface PaddleSdk {
+  Environment: {
+    set: (environment: 'sandbox') => void;
+  };
+  Initialize: (options: {
+    token: string;
+    eventCallback?: (event: PaddleEvent) => void;
+  }) => void;
+  Checkout: {
+    open: (options: {
+      transactionId: string;
+      customer?: { email: string };
+      settings?: {
+        displayMode?: 'overlay';
+        theme?: 'light' | 'dark';
+      };
+    }) => void;
+  };
+}
+
+declare global {
+  interface Window {
+    Paddle?: PaddleSdk;
+    __vdPaddleInitialized?: boolean;
+  }
+}
+
+export const BILLING_PLANS: readonly BillingPlan[] = [
+  { code: 'vd_monthly', label: '月会员', priceCny: 19, durationLabel: '1 个自然月' },
+  { code: 'vd_yearly', label: '年会员', priceCny: 199, durationLabel: '1 个自然年' },
+];
+
+const PADDLE_CLIENT_TOKEN = (import.meta.env.VITE_PADDLE_CLIENT_TOKEN as string | undefined)?.trim() || '';
+const PADDLE_ENVIRONMENT = ((import.meta.env.VITE_PADDLE_ENVIRONMENT as string | undefined)?.trim().toLowerCase() || 'sandbox') === 'production'
+  ? 'production'
+  : 'sandbox';
+
+let paddleScriptPromise: Promise<PaddleSdk> | null = null;
+
+function billingApiError(payload: unknown, fallback: string): Error {
+  if (payload && typeof payload === 'object') {
+    const candidate = payload as Record<string, unknown>;
+    if (typeof candidate.error === 'string' && candidate.error) return new Error(candidate.error);
+  }
+  return new Error(fallback);
+}
+
+async function parseApiJson(response: Response): Promise<unknown> {
+  const text = await response.text();
+  if (!text) return null;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+}
+
+function loadPaddleScript(): Promise<PaddleSdk> {
+  if (typeof window === 'undefined') return Promise.reject(new Error('当前环境无法打开支付窗口。'));
+  if (window.Paddle) return Promise.resolve(window.Paddle);
+  if (paddleScriptPromise) return paddleScriptPromise;
+
+  paddleScriptPromise = new Promise<PaddleSdk>((resolve, reject) => {
+    const existing = document.querySelector<HTMLScriptElement>('script[data-vd-paddle="true"]');
+    const script = existing ?? document.createElement('script');
+
+    const handleLoad = () => {
+      if (window.Paddle) resolve(window.Paddle);
+      else reject(new Error('Paddle.js 已加载，但没有初始化支付接口。'));
+    };
+    const handleError = () => reject(new Error('Paddle.js 加载失败，请检查网络后重试。'));
+
+    script.addEventListener('load', handleLoad, { once: true });
+    script.addEventListener('error', handleError, { once: true });
+
+    if (!existing) {
+      script.src = 'https://cdn.paddle.com/paddle/v2/paddle.js';
+      script.async = true;
+      script.dataset.vdPaddle = 'true';
+      document.head.appendChild(script);
+    }
+  });
+
+  return paddleScriptPromise;
+}
+
+async function initializePaddle(): Promise<PaddleSdk> {
+  if (!PADDLE_CLIENT_TOKEN) throw new Error('Paddle 客户端令牌尚未配置。');
+  const paddle = await loadPaddleScript();
+  if (window.__vdPaddleInitialized) return paddle;
+
+  if (PADDLE_ENVIRONMENT === 'sandbox') paddle.Environment.set('sandbox');
+  paddle.Initialize({
+    token: PADDLE_CLIENT_TOKEN,
+    eventCallback: (event) => {
+      window.dispatchEvent(new CustomEvent<PaddleEvent>('vd:paddle-event', { detail: event }));
+    },
+  });
+  window.__vdPaddleInitialized = true;
+  return paddle;
+}
+
+export function isPaddleClientConfigured(): boolean {
+  return Boolean(PADDLE_CLIENT_TOKEN);
+}
+
+export function isActiveMembership(membership: MembershipRecord | null, now = new Date()): boolean {
+  if (!membership) return false;
+  const expiresAt = new Date(membership.expires_at).getTime();
+  return Number.isFinite(expiresAt) && expiresAt > now.getTime();
+}
+
+export function getPlan(planCode: BillingPlanCode): BillingPlan {
+  return BILLING_PLANS.find((plan) => plan.code === planCode) ?? BILLING_PLANS[0];
+}
+
+export async function getBillingSnapshot(session: SupabaseSession): Promise<BillingSnapshot> {
+  const userId = encodeURIComponent(session.user.id);
+  const [memberships, orders] = await Promise.all([
+    supabase.rest<MembershipRecord[]>(
+      `memberships?select=user_id,plan_code,starts_at,expires_at,source,updated_at&user_id=eq.${userId}&limit=1`,
+      {},
+      session,
+    ),
+    supabase.rest<BillingOrder[]>(
+      `billing_orders?select=id,plan_code,amount_minor,currency,status,provider_transaction_id,checkout_created_at,paid_at,refunded_at,created_at&user_id=eq.${userId}&order=created_at.desc&limit=8`,
+      {},
+      session,
+    ),
+  ]);
+
+  return {
+    membership: memberships[0] ?? null,
+    orders: Array.isArray(orders) ? orders : [],
+  };
+}
+
+export async function createBillingCheckout(planCode: BillingPlanCode, session: SupabaseSession): Promise<CheckoutResponse> {
+  const response = await fetch('/api/billing-checkout', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${session.access_token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ planCode }),
+  });
+  const payload = await parseApiJson(response);
+  if (!response.ok) throw billingApiError(payload, '暂时无法创建支付订单。');
+  if (!payload || typeof payload !== 'object') throw new Error('支付服务返回了无效响应。');
+
+  const checkout = payload as Partial<CheckoutResponse>;
+  if (!checkout.ok || typeof checkout.orderId !== 'string' || typeof checkout.transactionId !== 'string') {
+    throw new Error('支付服务没有返回有效订单。');
+  }
+  return checkout as CheckoutResponse;
+}
+
+export async function openPaddleCheckout(transactionId: string, email?: string): Promise<void> {
+  const paddle = await initializePaddle();
+  paddle.Checkout.open({
+    transactionId,
+    customer: email ? { email } : undefined,
+    settings: { displayMode: 'overlay', theme: 'light' },
+  });
+}

--- a/supabase/migrations/20260823193000_billing_v1.sql
+++ b/supabase/migrations/20260823193000_billing_v1.sql
@@ -1,0 +1,332 @@
+-- Visual Deadline billing v1
+-- Owns VD orders, grants and membership state while keeping Paddle replaceable.
+-- Apply this migration before enabling checkout in production.
+
+begin;
+
+create table if not exists public.billing_orders (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  provider text not null default 'paddle' check (provider in ('paddle')),
+  provider_transaction_id text unique,
+  provider_customer_id text,
+  plan_code text not null check (plan_code in ('vd_monthly', 'vd_yearly')),
+  amount_minor integer not null check (amount_minor > 0),
+  currency text not null default 'CNY' check (currency = 'CNY'),
+  status text not null default 'pending' check (status in ('pending', 'paid', 'failed', 'canceled', 'partially_refunded', 'refunded')),
+  provider_error_code text,
+  checkout_created_at timestamptz not null default now(),
+  paid_at timestamptz,
+  refunded_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint billing_orders_vd_price_check check (
+    (plan_code = 'vd_monthly' and amount_minor = 1900)
+    or (plan_code = 'vd_yearly' and amount_minor = 19900)
+  )
+);
+
+create table if not exists public.membership_grants (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  source text not null check (source in ('paddle', 'admin_grant')),
+  plan_code text not null check (plan_code in ('vd_monthly', 'vd_yearly')),
+  duration_months integer not null check (duration_months in (1, 12)),
+  order_id uuid unique references public.billing_orders(id) on delete set null,
+  granted_at timestamptz not null default now(),
+  period_start timestamptz,
+  period_end timestamptz,
+  revoked_at timestamptz,
+  revoke_reason text,
+  created_by uuid references auth.users(id) on delete set null,
+  note text,
+  created_at timestamptz not null default now()
+);
+
+create table if not exists public.memberships (
+  user_id uuid primary key references auth.users(id) on delete cascade,
+  plan_code text not null check (plan_code in ('vd_monthly', 'vd_yearly')),
+  starts_at timestamptz not null,
+  expires_at timestamptz not null,
+  source text not null check (source in ('paddle', 'admin_grant')),
+  last_grant_id uuid references public.membership_grants(id) on delete set null,
+  updated_at timestamptz not null default now(),
+  constraint memberships_valid_period check (expires_at > starts_at)
+);
+
+create table if not exists public.billing_events (
+  id text primary key,
+  provider text not null default 'paddle' check (provider in ('paddle')),
+  event_type text not null,
+  provider_transaction_id text,
+  outcome text not null,
+  occurred_at timestamptz,
+  processed_at timestamptz not null default now()
+);
+
+create index if not exists billing_orders_user_created_idx on public.billing_orders(user_id, created_at desc);
+create index if not exists billing_orders_provider_transaction_idx on public.billing_orders(provider_transaction_id);
+create index if not exists membership_grants_user_granted_idx on public.membership_grants(user_id, granted_at, created_at);
+create index if not exists membership_grants_order_idx on public.membership_grants(order_id);
+create index if not exists billing_events_transaction_idx on public.billing_events(provider_transaction_id);
+
+create or replace function public.set_billing_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+drop trigger if exists billing_orders_set_updated_at on public.billing_orders;
+create trigger billing_orders_set_updated_at
+before update on public.billing_orders
+for each row execute function public.set_billing_updated_at();
+
+drop trigger if exists memberships_set_updated_at on public.memberships;
+create trigger memberships_set_updated_at
+before update on public.memberships
+for each row execute function public.set_billing_updated_at();
+
+alter table public.billing_orders enable row level security;
+alter table public.membership_grants enable row level security;
+alter table public.memberships enable row level security;
+alter table public.billing_events enable row level security;
+
+drop policy if exists billing_orders_select_own on public.billing_orders;
+create policy billing_orders_select_own
+on public.billing_orders
+for select
+to authenticated
+using (auth.uid() = user_id);
+
+drop policy if exists memberships_select_own on public.memberships;
+create policy memberships_select_own
+on public.memberships
+for select
+to authenticated
+using (auth.uid() = user_id);
+
+-- Grants and provider events are audit/internal records. They intentionally have no
+-- authenticated-client policies; only service-role code operates on them.
+
+create or replace function public.billing_rebuild_membership(p_user_id uuid)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  grant_row record;
+  cursor_end timestamptz := null;
+  first_start timestamptz := null;
+  next_start timestamptz;
+  next_end timestamptz;
+  last_plan text := null;
+  last_source text := null;
+  last_grant uuid := null;
+begin
+  -- Serialize membership changes per user. Replayed/concurrent webhooks therefore
+  -- cannot double-extend a membership.
+  perform pg_advisory_xact_lock(hashtext(p_user_id::text));
+
+  for grant_row in
+    select id, plan_code, source, granted_at, duration_months
+    from public.membership_grants
+    where user_id = p_user_id
+      and revoked_at is null
+    order by granted_at asc, created_at asc, id asc
+  loop
+    if cursor_end is null or grant_row.granted_at > cursor_end then
+      next_start := grant_row.granted_at;
+    else
+      next_start := cursor_end;
+    end if;
+
+    next_end := next_start + make_interval(months => grant_row.duration_months);
+
+    update public.membership_grants
+    set period_start = next_start,
+        period_end = next_end
+    where id = grant_row.id;
+
+    if first_start is null then
+      first_start := next_start;
+    end if;
+
+    cursor_end := next_end;
+    last_plan := grant_row.plan_code;
+    last_source := grant_row.source;
+    last_grant := grant_row.id;
+  end loop;
+
+  if cursor_end is null then
+    delete from public.memberships where user_id = p_user_id;
+    return;
+  end if;
+
+  insert into public.memberships (user_id, plan_code, starts_at, expires_at, source, last_grant_id)
+  values (p_user_id, last_plan, first_start, cursor_end, last_source, last_grant)
+  on conflict (user_id) do update
+  set plan_code = excluded.plan_code,
+      starts_at = excluded.starts_at,
+      expires_at = excluded.expires_at,
+      source = excluded.source,
+      last_grant_id = excluded.last_grant_id,
+      updated_at = now();
+end;
+$$;
+
+create or replace function public.billing_apply_paddle_grant(
+  p_user_id uuid,
+  p_plan_code text,
+  p_order_id uuid,
+  p_granted_at timestamptz default now()
+)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  duration integer;
+begin
+  if p_plan_code = 'vd_monthly' then
+    duration := 1;
+  elsif p_plan_code = 'vd_yearly' then
+    duration := 12;
+  else
+    raise exception 'Unsupported billing plan: %', p_plan_code;
+  end if;
+
+  if not exists (
+    select 1
+    from public.billing_orders
+    where id = p_order_id
+      and user_id = p_user_id
+      and plan_code = p_plan_code
+      and provider = 'paddle'
+      and status in ('paid', 'partially_refunded')
+  ) then
+    raise exception 'Paid order does not match requested membership grant';
+  end if;
+
+  insert into public.membership_grants (
+    user_id,
+    source,
+    plan_code,
+    duration_months,
+    order_id,
+    granted_at
+  )
+  values (
+    p_user_id,
+    'paddle',
+    p_plan_code,
+    duration,
+    p_order_id,
+    coalesce(p_granted_at, now())
+  )
+  on conflict (order_id) do nothing;
+
+  perform public.billing_rebuild_membership(p_user_id);
+end;
+$$;
+
+create or replace function public.billing_revoke_order_grant(
+  p_order_id uuid,
+  p_reason text default 'refund',
+  p_revoked_at timestamptz default now()
+)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  target_user uuid;
+begin
+  select user_id into target_user
+  from public.membership_grants
+  where order_id = p_order_id
+  limit 1;
+
+  if target_user is null then
+    return;
+  end if;
+
+  update public.membership_grants
+  set revoked_at = coalesce(revoked_at, coalesce(p_revoked_at, now())),
+      revoke_reason = coalesce(revoke_reason, p_reason)
+  where order_id = p_order_id
+    and revoked_at is null;
+
+  perform public.billing_rebuild_membership(target_user);
+end;
+$$;
+
+create or replace function public.billing_admin_grant(
+  p_user_id uuid,
+  p_plan_code text,
+  p_granted_at timestamptz default now(),
+  p_created_by uuid default null,
+  p_note text default null
+)
+returns uuid
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  duration integer;
+  new_grant_id uuid;
+begin
+  if p_plan_code = 'vd_monthly' then
+    duration := 1;
+  elsif p_plan_code = 'vd_yearly' then
+    duration := 12;
+  else
+    raise exception 'Unsupported billing plan: %', p_plan_code;
+  end if;
+
+  insert into public.membership_grants (
+    user_id,
+    source,
+    plan_code,
+    duration_months,
+    granted_at,
+    created_by,
+    note
+  )
+  values (
+    p_user_id,
+    'admin_grant',
+    p_plan_code,
+    duration,
+    coalesce(p_granted_at, now()),
+    p_created_by,
+    p_note
+  )
+  returning id into new_grant_id;
+
+  perform public.billing_rebuild_membership(p_user_id);
+  return new_grant_id;
+end;
+$$;
+
+revoke all on function public.billing_rebuild_membership(uuid) from public, anon, authenticated;
+revoke all on function public.billing_apply_paddle_grant(uuid, text, uuid, timestamptz) from public, anon, authenticated;
+revoke all on function public.billing_revoke_order_grant(uuid, text, timestamptz) from public, anon, authenticated;
+revoke all on function public.billing_admin_grant(uuid, text, timestamptz, uuid, text) from public, anon, authenticated;
+
+grant execute on function public.billing_rebuild_membership(uuid) to service_role;
+grant execute on function public.billing_apply_paddle_grant(uuid, text, uuid, timestamptz) to service_role;
+grant execute on function public.billing_revoke_order_grant(uuid, text, timestamptz) to service_role;
+grant execute on function public.billing_admin_grant(uuid, text, timestamptz, uuid, text) to service_role;
+
+grant select on public.billing_orders to authenticated;
+grant select on public.memberships to authenticated;
+
+commit;


### PR DESCRIPTION
## What this implements

- freezes VD membership v1 at **CNY 19/month** and **CNY 199/year** as one-time fixed-term purchases (no auto-renewal)
- adds VD-owned billing ledger and membership schema in Supabase
- adds authenticated `/api/billing-checkout` to create Paddle transactions server-side
- adds signed `/api/billing-webhook` processing for `transaction.completed` and refund adjustments
- grants membership only from verified server-side events, with idempotent stacking of natural-month/natural-year terms
- revokes the relevant grant on approved full refunds and preserves refund state across out-of-order webhook delivery
- adds **Free / Plus** membership badge beside the avatar and a GPT-style upgrade modal opened directly from the badge/account menu
- adds membership status, purchase controls and payment history to Personal Center
- updates Terms and Privacy disclosures for membership/payment processing
- adds `docs/BILLING_V1.md` with Sandbox -> Production configuration and smoke-test criteria

## Security / architecture

Paddle is treated as a replaceable provider. VD owns orders, grants, membership state and audit event IDs. The browser cannot grant membership, amounts are not user-supplied, and unknown Paddle transactions are not fulfilled.

## Validation

- Billing v1 migration has been applied to the live `visual-deadline` Supabase project.
- Latest Vercel preview build is green; only the existing Vite chunk-size warning remains.

## Still required before a real payment can succeed

1. create Paddle Sandbox one-time CNY 19 / CNY 199 prices;
2. set Vercel Paddle server secrets and browser-safe Paddle client token;
3. create the Paddle webhook destination at `/api/billing-webhook`;
4. run the Sandbox smoke test, then swap to live Paddle credentials and make one real purchase.

The app fails closed when Paddle is not configured: checkout cannot grant membership without verified server-side payment confirmation.